### PR TITLE
Add switcher scale option for indicator popup

### DIFF
--- a/wsmatrix@martin.zurowietz.de/WmOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WmOverride.js
@@ -300,6 +300,7 @@ var WmOverride = class {
                this.wm._workspaceSwitcherPopup = new IndicatorWsmatrixPopup(
                   this.rows,
                   this.columns,
+                  this.scale,
                   this.popupTimeout,
                   this.showWorkspaceNames
                 );

--- a/wsmatrix@martin.zurowietz.de/prefs.js
+++ b/wsmatrix@martin.zurowietz.de/prefs.js
@@ -26,12 +26,6 @@ var PrefsWidget = new GObject.Class({
 
       this._settings.connect(
          'changed::show-thumbnails',
-         this._setScaleSensitive.bind(this)
-      );
-      this._setScaleSensitive();
-
-      this._settings.connect(
-         'changed::show-thumbnails',
          this._setSetShowWorkspaceNamesSensitive.bind(this)
       );
       this._setSetShowWorkspaceNamesSensitive();
@@ -112,10 +106,6 @@ var PrefsWidget = new GObject.Class({
 
    _bindDblSpins: function () {
       this._getDblSpins().forEach(this._bindDblSpin, this);
-   },
-
-   _setScaleSensitive: function () {
-      this._getWidget('scale').set_sensitive(this._settings.get_boolean('show-thumbnails'));
    },
 
    _setSetShowWorkspaceNamesSensitive: function () {

--- a/wsmatrix@martin.zurowietz.de/settings.ui
+++ b/wsmatrix@martin.zurowietz.de/settings.ui
@@ -158,7 +158,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="valign">center</property>
-            <property name="label" translatable="yes">Show workspace thumbnails</property>
+            <property name="label" translatable="yes">Scale of workspace thumbnails</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -167,10 +167,18 @@
           </packing>
         </child>
         <child>
-          <object class="GtkSwitch" id="show_thumbnails">
+          <object class="GtkAdjustment" id="adjustment_scale">
+            <property name="lower">0.01</property>
+            <property name="upper">1.0</property>
+            <property name="value">0.1</property>
+            <property name="step-increment">0.01</property>
+          </object>
+          <object class="GtkSpinButton" id="scale">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="valign">center</property>
+            <property name="adjustment">adjustment_scale</property>
+            <property name="digits">2</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -196,7 +204,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="valign">center</property>
-            <property name="label" translatable="yes">Scale of workspace thumbnails</property>
+            <property name="label" translatable="yes">Show workspace thumbnails</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -205,18 +213,10 @@
           </packing>
         </child>
         <child>
-          <object class="GtkAdjustment" id="adjustment_scale">
-            <property name="lower">0.01</property>
-            <property name="upper">1.0</property>
-            <property name="value">0.1</property>
-            <property name="step-increment">0.01</property>
-          </object>
-          <object class="GtkSpinButton" id="scale">
+          <object class="GtkSwitch" id="show_thumbnails">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="valign">center</property>
-            <property name="adjustment">adjustment_scale</property>
-            <property name="digits">2</property>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
this PR makes the **scale** option available with or without thumbnails enabled, it also replicates the size of scaled thumbnails in indicators so the size of both switchers matches.

there is also a part of the code that tries to scale the `font-size` of `workspace name`, the font is calculated in pixels using the width of the indicators to make it fit in all scales and displays sizes.

the image below shows how the scale reproduces same position and size in both cases.

![screenshot](https://user-images.githubusercontent.com/25146039/57110841-9ebd8380-6d42-11e9-93fe-24d95a150c5c.jpg)
