### PR TITLE
Fix compatibility with GNOME 3.34

### DIFF
--- a/wsmatrix@martin.zurowietz.de/ThumbnailWsmatrixPopup.js
+++ b/wsmatrix@martin.zurowietz.de/ThumbnailWsmatrixPopup.js
@@ -141,7 +141,7 @@ class ThumbnailWsmatrixPopup extends BaseWorkspaceSwitcherPopup {
          for (let i = 0; i < this._workspaceManager.n_workspaces; i++) {
             let workspace = this._workspaceManager.get_workspace_by_index(i);
             let thumbnail = new WorkspaceThumbnail(workspace, this._monitorIndex);
-            this._list.add_actor(thumbnail.actor);
+            this._list.add_actor(thumbnail);
          }
 
          // The workspace indicator is always last.

--- a/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
+++ b/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
@@ -180,8 +180,7 @@ var ThumbnailsBoxOverride = class {
       let spacing = themeNode.get_length('spacing');
 
       // Compute the scale we'll need once everything is updated
-      let nWorkspaces = workspaceManager.n_workspaces;
-      let totalSpacing = (nWorkspaces - 1) * spacing;
+      let totalSpacing = (this.getRows() - 1) * spacing;
       let availY = (box.y2 - box.y1) - totalSpacing;
 
       let newScale = (availY / this.getRows()) / portholeHeight;
@@ -207,13 +206,14 @@ var ThumbnailsBoxOverride = class {
 
       let thumbnailHeight = portholeHeight * this._scale;
       let thumbnailWidth = Math.round(portholeWidth * this._scale);
+      let thumbnailBoxWidth = thumbnailWidth * this.getColumns() + spacing * (this.getColumns() - 1);
       let roundedHScale = thumbnailWidth / portholeWidth;
 
       let slideOffset; // X offset when thumbnail is fully slid offscreen
       if (rtl)
-         slideOffset = - (thumbnailWidth + themeNode.get_padding(St.Side.LEFT));
+         slideOffset = - (thumbnailBoxWidth + themeNode.get_padding(St.Side.LEFT));
       else
-         slideOffset = thumbnailWidth + themeNode.get_padding(St.Side.RIGHT);
+         slideOffset = thumbnailBoxWidth + themeNode.get_padding(St.Side.RIGHT);
 
       let indicatorY1 = this._indicatorY;
       let indicatorY2;

--- a/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
+++ b/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
@@ -90,8 +90,10 @@ var ThumbnailsBoxOverride = class {
          let [w, h] = t.get_transformed_size();
          return y >= t.y && y <= t.y + h && x >= t.x && x <= t.x + w;
       });
-      if (thumbnail)
+
+      if (thumbnail) {
          thumbnail.activate(time);
+      }
    }
 
    // Overriding the Tweener animation to consider both vertical and horizontal changes

--- a/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
@@ -28,7 +28,6 @@ var WorkspacesDisplayOverride = class {
 
    // Allow scrolling workspaces in overview to go through rows and columns
    // original code goes only through rows.
-   // TODO: This can probably be removed starting with GNOME 3.34.
    _onScrollEvent(actor, event) {
       if (!this.actor.mapped)
          return Clutter.EVENT_PROPAGATE;

--- a/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
@@ -14,12 +14,15 @@ var WorkspacesDisplayOverride = class {
    overrideOriginalProperties() {
       this.workspacesDisplay._overrideProperties = {
          _onScrollEvent: this.workspacesDisplay._onScrollEvent,
+         _onKeyPressEvent: this.workspacesDisplay._onKeyPressEvent,
       };
       this.workspacesDisplay._onScrollEvent = this._onScrollEvent.bind(this.workspacesDisplay);
+      this.workspacesDisplay._onKeyPressEvent = this._onKeyPressEvent.bind(this.workspacesDisplay);
    }
 
    restoreOriginalProperties() {
       this.workspacesDisplay._onScrollEvent = this.workspacesDisplay._overrideProperties._onScrollEvent;
+      this.workspacesDisplay._onKeyPressEvent = this.workspacesDisplay._overrideProperties._onKeyPressEvent;
       delete this.workspacesDisplay._overrideProperties;
    }
 
@@ -39,9 +42,34 @@ var WorkspacesDisplayOverride = class {
 
       switch (event.get_scroll_direction()) {
          case Clutter.ScrollDirection.UP:
+         case Clutter.ScrollDirection.LEFT:
             targetIndex = Math.max(targetIndex - 1, 0);
             break;
          case Clutter.ScrollDirection.DOWN:
+         case Clutter.ScrollDirection.RIGHT:
+            targetIndex = Math.min(targetIndex + 1, workspaceManager.n_workspaces - 1);
+            break;
+         default:
+            return Clutter.EVENT_PROPAGATE;
+      }
+
+      Main.wm.actionMoveWorkspace(workspaceManager.get_workspace_by_index(targetIndex));
+      return Clutter.EVENT_STOP;
+   }
+
+   _onKeyPressEvent(actor, event) {
+      if (!this.actor.mapped)
+         return Clutter.EVENT_PROPAGATE;
+      let workspaceManager = global.workspace_manager;
+      let targetIndex = workspaceManager.get_active_workspace_index();
+
+      let activeWs = workspaceManager.get_active_workspace();
+      let ws;
+      switch (event.get_key_symbol()) {
+         case Clutter.KEY_Page_Up:
+            targetIndex = Math.max(targetIndex - 1, 0);
+            break;
+         case Clutter.KEY_Page_Down:
             targetIndex = Math.min(targetIndex + 1, workspaceManager.n_workspaces - 1);
             break;
          default:


### PR DESCRIPTION
`GNOME 3.34` broke the extension's overview feature, this PR tries to fix it.
There is a small issue that I noticed while changing the active workspace in the overview (either by clicking on the workspace thumbnail, or scrolling with the mouse wheel, or using the shortcuts page up/down), the workspace indicator seems to disappear sometimes, mostly when there are no windows running on that target workspace. I am not sure whether this is an upstream issue or an issue with the extension yet, I think it's with the extension since it seems to work just fine with the extension disabled.

