### PR TITLE
Fixes the workspace overview in GNOME Shell 3.34

### DIFF
--- a/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
+++ b/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
@@ -228,13 +228,21 @@ var ThumbnailsBoxOverride = class {
 
          y = box.y1 + (spacing + thumbnailHeight) * Math.floor(i / this.getColumns());
 
+         /**
+          * <= 3.32 thumbnail.slidePosition
+          * >= 3.34 thumbnail.slide_position
+          */
+         const slidePosition = (thumbnail.slide_position !== undefined)
+            ? thumbnail.slide_position
+            : thumbnail.slidePosition;
+
          let x1, x2;
          let currentColumn = (totalThumbnails - i - 1) % this.getColumns();
          if (rtl) {
-            x1 = box.x1 + slideOffset * thumbnail.slidePosition - ((thumbnailWidth + spacing) * currentColumn);
+            x1 = box.x1 + slideOffset * slidePosition - ((thumbnailWidth + spacing) * currentColumn);
             x2 = x1 + thumbnailWidth;
          } else {
-            x1 = box.x2 - thumbnailWidth + slideOffset * thumbnail.slidePosition - ((thumbnailWidth + spacing) * currentColumn);
+            x1 = box.x2 - thumbnailWidth + slideOffset * slidePosition - ((thumbnailWidth + spacing) * currentColumn);
             x2 = x1 + thumbnailWidth;
          }
 


### PR DESCRIPTION
If "Show workspace grid in the overview" is enabled for workspace matrix GNOME Shell 3.34 crashes. They've [changed](https://gitlab.gnome.org/GNOME/gnome-shell/commit/dfa41f6926ee250fbac182b329c15ac4b9ad4c55#6904b8757b0fdea1808dcba0e8da6b603139d774_341_350) the API.

This fix maintains backward compatibility for the previous GNOME Shell versions. I've added a short comment in the code to point that out and make it clear for other devs.