### PR TITLE
fix workspace switching animation in overview

### DIFF
--- a/wsmatrix@martin.zurowietz.de/OverviewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/OverviewOverride.js
@@ -2,6 +2,7 @@ const WsMatrix = imports.misc.extensionUtils.getCurrentExtension();
 const Main = imports.ui.main;
 const DisplayWrapper = WsMatrix.imports.DisplayWrapper.DisplayWrapper;
 const WorkspacesDisplayOverride = WsMatrix.imports.WorkspacesDisplayOverride.WorkspacesDisplayOverride;
+const WorkspacesViewOverride = WsMatrix.imports.WorkspacesViewOverride.WorkspacesViewOverride;
 const ThumbnailsBoxOverride = WsMatrix.imports.ThumbnailsBoxOverride.ThumbnailsBoxOverride;
 
 var OverviewOverride = class {
@@ -12,6 +13,7 @@ var OverviewOverride = class {
       this._keybindings = keybindings;
       this._thumbnailsBoxOverride = null;
       this._workspacesDisplayOverride = null;
+      this._workspacesViewOverride = null;
       this._overrideActive = false;
 
       this._handleNumberOfWorkspacesChanged();
@@ -77,12 +79,15 @@ var OverviewOverride = class {
       this._workspacesDisplayOverride = new WorkspacesDisplayOverride(workspacesDisplay);
       let thumbnailsBox = Main.overview._controls._thumbnailsBox;
       this._thumbnailsBoxOverride = new ThumbnailsBoxOverride(thumbnailsBox, this.rows, this.columns);
+      this._workspacesViewOverride = new WorkspacesViewOverride(this.settings);
    }
 
    _deactivateOverride() {
       this._overrideActive = false;
       this._workspacesDisplayOverride.destroy();
       this._workspacesDisplayOverride = null;
+      this._workspacesViewOverride.destroy();
+      this._workspacesViewOverride = null;
       this._thumbnailsBoxOverride.destroy();
       this._thumbnailsBoxOverride = null;
    }

--- a/wsmatrix@martin.zurowietz.de/WmOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WmOverride.js
@@ -6,6 +6,7 @@ const Shell = imports.gi.Shell;
 const Meta = imports.gi.Meta;
 const Main = imports.ui.main;
 const Gio = imports.gi.Gio;
+const WorkspacesView = imports.ui.workspacesView.WorkspacesView;
 
 const WraparoundMode = {
     NONE: 0,
@@ -27,6 +28,7 @@ var WmOverride = class {
 
       this._overrideDynamicWorkspaces();
       this._overrideKeybindingHandlers();
+      this._extendWorkspacesView();
       this._handleNumberOfWorkspacesChanged();
       this._handlePopupTimeoutChanged();
       this._handleScaleChanged();
@@ -39,7 +41,6 @@ var WmOverride = class {
       this._notify();
       this._addKeybindings();
       this._connectOverview();
-      this._connectLayoutManager();
    }
 
    destroy() {
@@ -270,6 +271,11 @@ var WmOverride = class {
             );
          }
       }
+   }
+
+   _extendWorkspacesView() {
+      WorkspacesView.prototype.getRows = () => this.rows;
+      WorkspacesView.prototype.getColumns = () => this.columns;
    }
 
    _restoreKeybindingHandlers() {

--- a/wsmatrix@martin.zurowietz.de/WmOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WmOverride.js
@@ -6,7 +6,6 @@ const Shell = imports.gi.Shell;
 const Meta = imports.gi.Meta;
 const Main = imports.ui.main;
 const Gio = imports.gi.Gio;
-const WorkspacesView = imports.ui.workspacesView.WorkspacesView;
 
 const WraparoundMode = {
     NONE: 0,
@@ -28,7 +27,6 @@ var WmOverride = class {
 
       this._overrideDynamicWorkspaces();
       this._overrideKeybindingHandlers();
-      this._extendWorkspacesView();
       this._handleNumberOfWorkspacesChanged();
       this._handlePopupTimeoutChanged();
       this._handleScaleChanged();
@@ -41,6 +39,7 @@ var WmOverride = class {
       this._notify();
       this._addKeybindings();
       this._connectOverview();
+      this._connectLayoutManager();
    }
 
    destroy() {
@@ -271,11 +270,6 @@ var WmOverride = class {
             );
          }
       }
-   }
-
-   _extendWorkspacesView() {
-      WorkspacesView.prototype.getRows = () => this.rows;
-      WorkspacesView.prototype.getColumns = () => this.columns;
    }
 
    _restoreKeybindingHandlers() {

--- a/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
@@ -54,16 +54,8 @@ var WorkspacesViewOverride = class {
       delete WorkspacesView.prototype.getColumns;
    }
 
-   setRows(rows) {
-      this.rows = rows;
-   }
-
    getRows() {
       return this.rows;
-   }
-
-   setColumns(columns) {
-      this.columns = columns;
    }
 
    getColumns() {

--- a/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
@@ -9,9 +9,6 @@ var WorkspacesViewOverride = class {
       this.overrideOriginalProperties();
       this._connectSettings();
       this._handleNumberOfWorkspacesChanged();
-
-      this.rows;
-      this.columns;
    }
 
    destroy() {
@@ -39,8 +36,6 @@ var WorkspacesViewOverride = class {
    _handleNumberOfWorkspacesChanged() {
       this.rows = this.settings.get_int('num-rows');
       this.columns = this.settings.get_int('num-columns');
-      WorkspacesView.prototype.getRows = this.getRows.bind(this);
-      WorkspacesView.prototype.getColumns = this.getColumns.bind(this);
    }
 
    overrideOriginalProperties() {
@@ -48,6 +43,8 @@ var WorkspacesViewOverride = class {
          _updateWorkspaceActors: WorkspacesView.prototype._updateWorkspaceActors,
       };
       WorkspacesView.prototype._updateWorkspaceActors = this._updateWorkspaceActors;
+      WorkspacesView.prototype.getRows = this.getRows.bind(this);
+      WorkspacesView.prototype.getColumns = this.getColumns.bind(this);
    }
 
    restoreOriginalProperties() {

--- a/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
@@ -1,0 +1,139 @@
+const { Clutter } = imports.gi;
+const workspacesView = imports.ui.workspacesView;
+const WorkspacesView = workspacesView.WorkspacesView;
+const Tweener = imports.ui.tweener;
+
+var WorkspacesViewOverride = class {
+   constructor(settings) {
+      this.settings = settings;
+      this.overrideOriginalProperties();
+      this._connectSettings();
+      this._handleNumberOfWorkspacesChanged();
+
+      this.rows;
+      this.columns;
+   }
+
+   destroy() {
+      this._disconnectSettings();
+      this.restoreOriginalProperties();
+   }
+
+   _connectSettings() {
+      this.settingsHandlerRows = this.settings.connect(
+         'changed::num-rows',
+         this._handleNumberOfWorkspacesChanged.bind(this)
+      );
+
+      this.settingsHandlerColumns = this.settings.connect(
+         'changed::num-columns',
+         this._handleNumberOfWorkspacesChanged.bind(this)
+      );
+   }
+
+   _disconnectSettings() {
+      this.settings.disconnect(this.settingsHandlerRows);
+      this.settings.disconnect(this.settingsHandlerColumns);
+   }
+
+   _handleNumberOfWorkspacesChanged() {
+      this.rows = this.settings.get_int('num-rows');
+      this.columns = this.settings.get_int('num-columns');
+      WorkspacesView.prototype.getRows = this.getRows.bind(this);
+      WorkspacesView.prototype.getColumns = this.getColumns.bind(this);
+   }
+
+   overrideOriginalProperties() {
+      WorkspacesView.prototype._overrideProperties = {
+         _updateWorkspaceActors: WorkspacesView.prototype._updateWorkspaceActors,
+      };
+      WorkspacesView.prototype._updateWorkspaceActors = this._updateWorkspaceActors;
+   }
+
+   restoreOriginalProperties() {
+      WorkspacesView.prototype._updateWorkspaceActors = WorkspacesView.prototype._overrideProperties._updateWorkspaceActors;
+      delete WorkspacesView.prototype._overrideProperties;
+      delete WorkspacesView.prototype.getRows;
+      delete WorkspacesView.prototype.getColumns;
+   }
+
+   setRows(rows) {
+      this.rows = rows;
+   }
+
+   getRows() {
+      return this.rows;
+   }
+
+   setColumns(columns) {
+      this.columns = columns;
+   }
+
+   getColumns() {
+      return this.columns;
+   }
+
+   // Update workspace actors parameters
+   // @showAnimation: iff %true, transition between states
+   _updateWorkspaceActors(showAnimation) {
+      let workspaceManager = global.workspace_manager;
+      let active = workspaceManager.get_active_workspace_index();
+      let activeRow = Math.floor(active / this.getColumns());
+      let activeColumn = active % this.getColumns();
+
+      this._animating = showAnimation;
+
+      for (let w = 0; w < this._workspaces.length; w++) {
+         let workspace = this._workspaces[w];
+         let workspaceRow = Math.floor(w / this.getColumns());
+         let workspaceColumn = w % this.getColumns();
+
+         workspace.actor.remove_all_transitions();
+
+
+         let params = {};
+         if (this.actor.text_direction == Clutter.TextDirection.RTL) {
+            params.x = (activeColumn - workspaceColumn) * this._fullGeometry.width;
+         } else {
+            params.x = (workspaceColumn - activeColumn) * this._fullGeometry.width;
+         }
+         params.y = (workspaceRow - activeRow) * this._fullGeometry.height;
+
+         if (showAnimation) {
+            let easeParams = Object.assign(params);
+            
+            // we have to call _updateVisibility() once before the
+            // animation and once afterwards - it does not really
+            // matter which tween we use, so we pick the first one ...
+            if (w == 0) {
+               this._updateVisibility();
+               easeParams.onComplete = () => {
+                  this._animating = false;
+                  this._updateVisibility();
+               };
+            }
+
+            if (workspace.actor.ease === undefined) {
+               //maintain compatibility with gnome prior to 3.34
+               easeParams = Object.assign(params, {
+                  time: workspacesView.WORKSPACE_SWITCH_TIME,
+                  transition: 'easeOutQuad'
+               });
+               Tweener.addTween(workspace.actor, easeParams);
+            }
+            else {
+               easeParams = Object.assign(params, {
+                  duration: workspacesView.WORKSPACE_SWITCH_TIME,
+                  mode: Clutter.AnimationMode.EASE_OUT_QUAD
+               });
+               workspace.actor.ease(easeParams);
+            }
+         } else {
+            workspace.actor.set(params);
+            if (w == 0) {
+               this._updateVisibility();
+            }
+         }
+      }
+   }
+}

--- a/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
@@ -7,10 +7,40 @@ var WorkspacesViewOverride = class {
    constructor(settings) {
       this.settings = settings;
       this.overrideOriginalProperties();
+      this._connectSettings();
+      this._handleNumberOfWorkspacesChanged();
+
+      this.rows;
+      this.columns;
    }
 
    destroy() {
+      this._disconnectSettings();
       this.restoreOriginalProperties();
+   }
+
+   _connectSettings() {
+      this.settingsHandlerRows = this.settings.connect(
+         'changed::num-rows',
+         this._handleNumberOfWorkspacesChanged.bind(this)
+      );
+
+      this.settingsHandlerColumns = this.settings.connect(
+         'changed::num-columns',
+         this._handleNumberOfWorkspacesChanged.bind(this)
+      );
+   }
+
+   _disconnectSettings() {
+      this.settings.disconnect(this.settingsHandlerRows);
+      this.settings.disconnect(this.settingsHandlerColumns);
+   }
+
+   _handleNumberOfWorkspacesChanged() {
+      this.rows = this.settings.get_int('num-rows');
+      this.columns = this.settings.get_int('num-columns');
+      WorkspacesView.prototype.getRows = this.getRows.bind(this);
+      WorkspacesView.prototype.getColumns = this.getColumns.bind(this);
    }
 
    overrideOriginalProperties() {
@@ -23,6 +53,24 @@ var WorkspacesViewOverride = class {
    restoreOriginalProperties() {
       WorkspacesView.prototype._updateWorkspaceActors = WorkspacesView.prototype._overrideProperties._updateWorkspaceActors;
       delete WorkspacesView.prototype._overrideProperties;
+      delete WorkspacesView.prototype.getRows;
+      delete WorkspacesView.prototype.getColumns;
+   }
+
+   setRows(rows) {
+      this.rows = rows;
+   }
+
+   getRows() {
+      return this.rows;
+   }
+
+   setColumns(columns) {
+      this.columns = columns;
+   }
+
+   getColumns() {
+      return this.columns;
    }
 
    // Update workspace actors parameters

--- a/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
@@ -7,40 +7,10 @@ var WorkspacesViewOverride = class {
    constructor(settings) {
       this.settings = settings;
       this.overrideOriginalProperties();
-      this._connectSettings();
-      this._handleNumberOfWorkspacesChanged();
-
-      this.rows;
-      this.columns;
    }
 
    destroy() {
-      this._disconnectSettings();
       this.restoreOriginalProperties();
-   }
-
-   _connectSettings() {
-      this.settingsHandlerRows = this.settings.connect(
-         'changed::num-rows',
-         this._handleNumberOfWorkspacesChanged.bind(this)
-      );
-
-      this.settingsHandlerColumns = this.settings.connect(
-         'changed::num-columns',
-         this._handleNumberOfWorkspacesChanged.bind(this)
-      );
-   }
-
-   _disconnectSettings() {
-      this.settings.disconnect(this.settingsHandlerRows);
-      this.settings.disconnect(this.settingsHandlerColumns);
-   }
-
-   _handleNumberOfWorkspacesChanged() {
-      this.rows = this.settings.get_int('num-rows');
-      this.columns = this.settings.get_int('num-columns');
-      WorkspacesView.prototype.getRows = this.getRows.bind(this);
-      WorkspacesView.prototype.getColumns = this.getColumns.bind(this);
    }
 
    overrideOriginalProperties() {
@@ -53,24 +23,6 @@ var WorkspacesViewOverride = class {
    restoreOriginalProperties() {
       WorkspacesView.prototype._updateWorkspaceActors = WorkspacesView.prototype._overrideProperties._updateWorkspaceActors;
       delete WorkspacesView.prototype._overrideProperties;
-      delete WorkspacesView.prototype.getRows;
-      delete WorkspacesView.prototype.getColumns;
-   }
-
-   setRows(rows) {
-      this.rows = rows;
-   }
-
-   getRows() {
-      return this.rows;
-   }
-
-   setColumns(columns) {
-      this.columns = columns;
-   }
-
-   getColumns() {
-      return this.columns;
    }
 
    // Update workspace actors parameters


### PR DESCRIPTION
This PR fixes animation in overview, current behavior (`GNOME 3.34`) animates workspaces horizontally. This PR animates workspaces vertically and horizontally as needed.

Fixes #56 