### PR TITLE
[WIP] Workspace popup dissappear with modifer key

### DIFF
--- a/wsmatrix@martin.zurowietz.de/BaseWorkspaceSwitcherPopup.js
+++ b/wsmatrix@martin.zurowietz.de/BaseWorkspaceSwitcherPopup.js
@@ -1,12 +1,18 @@
-const { GLib, GObject} = imports.gi;
+const { Clutter, GLib, GObject} = imports.gi;
 const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup.WorkspaceSwitcherPopup;
 const Mainloop = imports.mainloop;
+const Main = imports.ui.main;
+const WM = Main.wm;
+
+var ANIMATION_TIME = 100;
 
 var BaseWorkspaceSwitcherPopup = GObject.registerClass(
 class BaseWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup {
-   _init(popupTimeout) {
+   _init(popupTimeout, monitorIndex) {
       super._init();
       this._popupTimeout = popupTimeout;
+      this._monitorIndex = monitorIndex;
+      this._haveModal = false;
    }
 
    display(direction, activeWorkspaceIndex) {
@@ -20,6 +26,102 @@ class BaseWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup {
       if (this._popupTimeout > 0) {
          this._timeoutId = Mainloop.timeout_add(this._popupTimeout, this._onTimeout.bind(this));
          GLib.Source.set_name_by_id(this._timeoutId, '[gnome-shell] this._onTimeout');
+      } else if (!this._haveModal && this._popupTimeout == 0 && this._monitorIndex == Main.layoutManager.primaryMonitor.index){
+         Main.pushModal(this);
+         this._haveModal = true;
       }
    }
+
+   vfunc_key_release_event(keyEvent) {
+      let key = keyEvent.keyval;
+
+      switch (key) {
+         case Clutter.KEY_Up:
+            WM.wsmatrix.overrideWorkspace._workspaceOverviewMoveUp();
+            break;
+         case Clutter.KEY_Down:
+            WM.wsmatrix.overrideWorkspace._workspaceOverviewMoveDown();
+            break;
+         case Clutter.KEY_Left:
+            WM.wsmatrix.overrideWorkspace._workspaceOverviewMoveLeft();
+            break;
+         case Clutter.KEY_Right:
+            WM.wsmatrix.overrideWorkspace._workspaceOverviewMoveRight();
+            break;
+      }
+
+      // keypad keys, from 1 (65457) to 9 (65465)
+      if (key >= 65457 && key <= 65465) {
+         // the key number from 1 to 9
+         let keyNumber = key - 65457 + 1;
+         WM.wsmatrix.overrideWorkspace._moveToWorkspaceIndex(this._keyNumToWorkspace(keyNumber) - 1);
+      }
+
+      // arrow keys
+      if (key == Clutter.KEY_Alt_L || key == Clutter.KEY_Alt_R || key == Clutter.KEY_Ctrl_L || key == Clutter.KEY_Ctrl_R) {
+         WM.wsmatrix.overrideWorkspace._hideWorkspaceSwitcherPopup();
+      }
+
+      return Clutter.EVENT_STOP;
+   }
+
+   _keyNumToWorkspace(keyNumber) {
+      switch (keyNumber) {
+         case 7:
+            return 1;
+         case 8:
+            return 2;
+         case 9:
+            return 3;
+         case 1:
+            return 7;
+         case 2:
+            return 8;
+         case 3:
+            return 9;
+         default:
+            return keyNumber;
+      }
+   }
+
+   _popModal() {
+      if (this._haveModal) {
+         Main.popModal(this);
+         this._haveModal = false;
+      }
+   }
+
+   _onTimeout() {
+      if (this._timeoutId !== 0) {
+         GLib.source_remove(this._timeoutId);
+         this._timeoutId = 0;
+      }
+
+      let _this = this;
+      this._container.ease({
+          opacity: 0.0,
+          duration: ANIMATION_TIME,
+          mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+          onComplete: function() {
+             if (_this._popupTimeout === 0) {
+                // we pop the modal and then hide, otherwise the focus and keys will be sent to the popup
+               _this._popModal();
+               _this.hide();
+             } else {
+               _this.destroy();
+             }
+          } 
+      });
+
+      return GLib.SOURCE_REMOVE;
+  }
+
+  _hide() {
+      if (this._popupTimeout === 0) {
+         // popup timeout = 0 means hide on key mask release
+         this._onTimeout();
+      } else {
+         this.hide();
+      }
+  }
 });

--- a/wsmatrix@martin.zurowietz.de/IndicatorWsmatrixPopup.js
+++ b/wsmatrix@martin.zurowietz.de/IndicatorWsmatrixPopup.js
@@ -89,8 +89,7 @@ class IndicatorWsmatrixPopupList extends WorkspaceSwitcherPopupList {
 var IndicatorWsmatrixPopup = GObject.registerClass(
 class IndicatorWsmatrixPopup extends BaseWorkspaceSwitcherPopup {
    _init(rows, columns, popupTimeout, showWorkspaceNames, monitorIndex) {
-      this._monitorIndex = monitorIndex;
-      super._init(popupTimeout);
+      super._init(popupTimeout, monitorIndex);
       this.showWorkspaceNames = showWorkspaceNames;
       let oldList = this._list;
       this._list = new IndicatorWsmatrixPopupList(rows, columns, this._monitorIndex);

--- a/wsmatrix@martin.zurowietz.de/ThumbnailWsmatrixPopup.js
+++ b/wsmatrix@martin.zurowietz.de/ThumbnailWsmatrixPopup.js
@@ -107,9 +107,8 @@ class ThumbnailWsmatrixPopupList extends WorkspaceSwitcherPopupList {
 var ThumbnailWsmatrixPopup = GObject.registerClass(
 class ThumbnailWsmatrixPopup extends BaseWorkspaceSwitcherPopup {
    _init(rows, columns, scale, popupTimeout, hideOnly, monitorIndex) {
-      super._init(popupTimeout);
+      super._init(popupTimeout, monitorIndex);
       this._hideOnly = hideOnly;
-      this._monitorIndex = monitorIndex;
       this._workspaceManager = DisplayWrapper.getWorkspaceManager();
       let oldList = this._list;
       this._list = new ThumbnailWsmatrixPopupList(rows, columns, scale, this._monitorIndex);
@@ -167,7 +166,7 @@ class ThumbnailWsmatrixPopup extends BaseWorkspaceSwitcherPopup {
 
    destroy(force = false) {
       if (this._hideOnly && !force) {
-         this.hide();
+         this._hide();
       } else {
          super.destroy();
       }

--- a/wsmatrix@martin.zurowietz.de/WmOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WmOverride.js
@@ -380,7 +380,7 @@ var WmOverride = class {
       else
          this.wm.actionMoveWindow(window, newWs);
 
-      if (!Main.overview.visible && this.popupTimeout > 0) {
+      if (!Main.overview.visible && this.popupTimeout >= 0) {
          this.monitors.forEach((monitor) => {
             let monitorIndex = monitor.index;
 
@@ -416,6 +416,15 @@ var WmOverride = class {
             } else {
                this.wm._wsPopupList[monitorIndex].destroy();
             }
+         }
+      });
+   }
+
+   _hideWorkspaceSwitcherPopup() {
+      this.monitors.forEach((monitor) => {
+         let monitorIndex = monitor.index;
+         if (this.wm._wsPopupList[monitorIndex]) {
+            this.wm._wsPopupList[monitorIndex]._hide();
          }
       });
    }
@@ -512,8 +521,7 @@ var WmOverride = class {
       }
    }
 
-   _moveToWorkspace(direction) {
-      let workspace = this._getTargetWorkspace(direction);
+   _moveToWorkspace(workspace, direction = -1) {
       this.wm.actionMoveWorkspace(workspace);
       this.monitors.forEach((monitor) => {
          let monitorIndex = monitor.index;
@@ -523,20 +531,30 @@ var WmOverride = class {
       });
    }
 
+   _moveToWorkspaceDirection(direction) {
+      let workspace = this._getTargetWorkspace(direction);
+      this._moveToWorkspace(workspace, direction);
+   }
+
+   _moveToWorkspaceIndex(index) {
+      let workspace = this.wsManager.get_workspace_by_index(index);
+      this._moveToWorkspace(workspace);
+   }
+
    _workspaceOverviewMoveRight() {
-      this._moveToWorkspace(Meta.MotionDirection.RIGHT);
+      this._moveToWorkspaceDirection(Meta.MotionDirection.RIGHT);
    }
 
    _workspaceOverviewMoveLeft() {
-      this._moveToWorkspace(Meta.MotionDirection.LEFT);
+      this._moveToWorkspaceDirection(Meta.MotionDirection.LEFT);
    }
 
    _workspaceOverviewMoveUp() {
-      this._moveToWorkspace(Meta.MotionDirection.UP);
+      this._moveToWorkspaceDirection(Meta.MotionDirection.UP);
    }
 
    _workspaceOverviewMoveDown() {
-      this._moveToWorkspace(Meta.MotionDirection.DOWN);
+      this._moveToWorkspaceDirection(Meta.MotionDirection.DOWN);
    }
 
    _workspaceOverviewConfirm() {

--- a/wsmatrix@martin.zurowietz.de/extension.js
+++ b/wsmatrix@martin.zurowietz.de/extension.js
@@ -4,6 +4,7 @@ const Meta = imports.gi.Meta;
 const Settings = WsMatrix.imports.Settings.Settings;
 const WmOverride = WsMatrix.imports.WmOverride.WmOverride;
 const OverviewOverride = WsMatrix.imports.OverviewOverride.OverviewOverride;
+const WM = imports.ui.main.wm;
 
 class WsMatrixExtension {
    constructor() {
@@ -23,6 +24,7 @@ let wsMatrix;
 
 function enable() {
    wsMatrix = new WsMatrixExtension();
+   WM.wsmatrix = wsMatrix;
 }
 
 function disable() {


### PR DESCRIPTION
works when popup timeout is set to zero
tasks left:

- [ ] allow configuration of `switch-to-workspace` modifier keys in preferences (`alt+ctrl` is currently used and only works for `switch-to-workspace`)
- [ ] allow configuration and handle `move-window-to-workspace` modifier key


known issues:
- [ ] releasing a key is not detected when a window is dragged from the workspace popup (must release it twice after dropping the window so the focus is set back the workspace popup)

fixes #59 and builds a very good base for #60 

contributions are appreciated.
