### PR TITLE
Wrap remaining ES6 classes in GObject.registerClass().

### DIFF
--- a/wsmatrix@martin.zurowietz.de/Settings.js
+++ b/wsmatrix@martin.zurowietz.de/Settings.js
@@ -1,9 +1,11 @@
 const WsMatrix = imports.misc.extensionUtils.getCurrentExtension();
+const GObject = imports.gi.GObject;
 const Gio = imports.gi.Gio;
 const GioSSS = Gio.SettingsSchemaSource;
 
-var Settings = class Settings extends Gio.Settings {
-  constructor(schema) {
+var Settings = GObject.registerClass(
+class Settings extends Gio.Settings {
+  _init(schema) {
     let schemaDir    = WsMatrix.dir.get_child('schemas');
     let schemaSource = null;
 
@@ -20,6 +22,6 @@ var Settings = class Settings extends Gio.Settings {
       throw new Error(message + '. Please check your installation.');
     }
 
-    super({ settings_schema: schemaObj });
+    super._init({ settings_schema: schemaObj });
   }
-};
+});

--- a/wsmatrix@martin.zurowietz.de/WsmatrixThumbnail.js
+++ b/wsmatrix@martin.zurowietz.de/WsmatrixThumbnail.js
@@ -4,10 +4,10 @@ const WorkspaceThumbnail = imports.ui.workspaceThumbnail.WorkspaceThumbnail;
 
 var WsmatrixThumbnail = GObject.registerClass(
 class WsmatrixThumbnail extends WorkspaceThumbnail {
-    constructor(metaWorkspace, monitorIndex) {
+    _init(metaWorkspace, monitorIndex) {
         let tempPrimaryIndex = Main.layoutManager.primaryIndex;
         Main.layoutManager.primaryIndex = monitorIndex;
-        super(metaWorkspace);
+        super._init(metaWorkspace);
         Main.layoutManager.primaryIndex = tempPrimaryIndex;
     }
 });

--- a/wsmatrix@martin.zurowietz.de/WsmatrixThumbnail.js
+++ b/wsmatrix@martin.zurowietz.de/WsmatrixThumbnail.js
@@ -1,11 +1,13 @@
+const GObject = imports.gi.GObject;
 const Main = imports.ui.main;
 const WorkspaceThumbnail = imports.ui.workspaceThumbnail.WorkspaceThumbnail;
 
-var WsmatrixThumbnail = class WsmatrixThumbnail extends WorkspaceThumbnail {
+var WsmatrixThumbnail = GObject.registerClass(
+class WsmatrixThumbnail extends WorkspaceThumbnail {
     constructor(metaWorkspace, monitorIndex) {
         let tempPrimaryIndex = Main.layoutManager.primaryIndex;
         Main.layoutManager.primaryIndex = monitorIndex;
         super(metaWorkspace);
         Main.layoutManager.primaryIndex = tempPrimaryIndex;
     }
-}
+});


### PR DESCRIPTION
 Override Gio.Settings._init instead of constructor.
Closes #77.