### PR TITLE
Fix overview compatibility with GNOME 3.36 (fixes #96)

### DIFF
--- a/wsmatrix@martin.zurowietz.de/BaseWorkspaceSwitcherPopup.js
+++ b/wsmatrix@martin.zurowietz.de/BaseWorkspaceSwitcherPopup.js
@@ -1,6 +1,5 @@
 const { GLib, GObject} = imports.gi;
 const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup.WorkspaceSwitcherPopup;
-const Mainloop = imports.mainloop;
 
 var BaseWorkspaceSwitcherPopup = GObject.registerClass(
 class BaseWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup {
@@ -13,12 +12,12 @@ class BaseWorkspaceSwitcherPopup extends WorkspaceSwitcherPopup {
       super.display(direction, activeWorkspaceIndex);
 
       if (this._timeoutId !== 0) {
-         Mainloop.source_remove(this._timeoutId);
+         GLib.source_remove(this._timeoutId);
          this._timeoutId = 0;
       }
 
       if (this._popupTimeout > 0) {
-         this._timeoutId = Mainloop.timeout_add(this._popupTimeout, this._onTimeout.bind(this));
+         this._timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, this._popupTimeout, this._onTimeout.bind(this));
          GLib.Source.set_name_by_id(this._timeoutId, '[gnome-shell] this._onTimeout');
       }
    }

--- a/wsmatrix@martin.zurowietz.de/IndicatorWsmatrixPopup.js
+++ b/wsmatrix@martin.zurowietz.de/IndicatorWsmatrixPopup.js
@@ -19,8 +19,7 @@ class IndicatorWsmatrixPopupList extends WorkspaceSwitcherPopupList {
       let workArea = Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex);
       let themeNode = this.get_theme_node();
 
-      let availHeight = workArea.height;
-      availHeight -= themeNode.get_vertical_padding();
+      let availHeight = workArea.height - themeNode.get_vertical_padding();
 
       let height = 0;
       let [, childNaturalHeight] = children[0].get_preferred_height(-1);
@@ -45,8 +44,7 @@ class IndicatorWsmatrixPopupList extends WorkspaceSwitcherPopupList {
       let workArea = Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex);
       let themeNode = this.get_theme_node();
 
-      let availWidth = workArea.width;
-      availWidth -= themeNode.get_horizontal_padding();
+      let availWidth = workArea.width - themeNode.get_horizontal_padding();
 
       let width = Math.round(this._childHeight * workArea.width / workArea.height) * this._columns;
 
@@ -56,7 +54,7 @@ class IndicatorWsmatrixPopupList extends WorkspaceSwitcherPopupList {
 
       this._childWidth = (width - spacing) / this._columns;
 
-      return themeNode.adjust_preferred_width(width, width);
+      return [width, width];
    }
 
    vfunc_allocate(box, flags) {
@@ -113,20 +111,13 @@ class IndicatorWsmatrixPopup extends BaseWorkspaceSwitcherPopup {
       this._container.x = workArea.x + Math.floor((workArea.width - containerNatWidth) / 2);
       this._container.y = workArea.y + Math.floor((workArea.height - containerNatHeight) / 2);
 
-      let indicators = this._list.get_children();
-      for (let i = 0; i < indicators.length; i++) {
-         if (this.showWorkspaceNames) {
-            let workspaceName = Meta.prefs_get_workspace_name(i);
-            indicators[i].child = new St.Label({
-               text: workspaceName,
+      if (this.showWorkspaceNames) {
+         this._list.get_children().forEach(function (indicator, index) {
+            indicator.child = new St.Label({
+               text: Meta.prefs_get_workspace_name(index),
                style_class: "ws-switcher-label"
             });
-         }
-         if (i === this._activeWorkspaceIndex && (this._direction == Meta.MotionDirection.UP || this._direction == Meta.MotionDirection.LEFT)) {
-            indicators[i].style_class = 'wsmatrix ws-switcher-active-up';
-         } else if (i === this._activeWorkspaceIndex) {
-            indicators[i].style_class = 'wsmatrix ws-switcher-active-down';
-         }
+         });
       }
    }
 });

--- a/wsmatrix@martin.zurowietz.de/OverviewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/OverviewOverride.js
@@ -75,9 +75,9 @@ var OverviewOverride = class {
 
    _activateOverride() {
       this._overrideActive = true;
-      let workspacesDisplay = Main.overview._controls.viewSelector._workspacesDisplay;
+      let workspacesDisplay = Main.overview._overview._controls.viewSelector._workspacesDisplay;
       this._workspacesDisplayOverride = new WorkspacesDisplayOverride(workspacesDisplay);
-      let thumbnailsBox = Main.overview._controls._thumbnailsBox;
+      let thumbnailsBox = Main.overview._overview._controls._thumbnailsBox;
       this._thumbnailsBoxOverride = new ThumbnailsBoxOverride(thumbnailsBox, this.rows, this.columns);
       this._workspacesViewOverride = new WorkspacesViewOverride(this.settings);
    }

--- a/wsmatrix@martin.zurowietz.de/ThumbnailWsmatrixPopup.js
+++ b/wsmatrix@martin.zurowietz.de/ThumbnailWsmatrixPopup.js
@@ -21,17 +21,17 @@ class ThumbnailWsmatrixPopupList extends WorkspaceSwitcherPopupList {
       let children = this.get_children();
       let workArea = Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex);
       let themeNode = this.get_theme_node();
+      let spacing = themeNode.get_length('spacing');
 
-      let availHeight = workArea.height;
-      availHeight -= themeNode.get_vertical_padding();
+      let availHeight = workArea.height - themeNode.get_vertical_padding();
 
       let height = this._rows * this._scale * children[0].get_height();
-      let spacing = this._itemSpacing * (this._rows - 1);
+      let totalSpacing = spacing * (this._rows - 1);
 
-      height += spacing;
+      height += totalSpacing;
       height = Math.round(Math.min(height, availHeight));
 
-      this._childHeight = Math.round((height - spacing) / this._rows);
+      this._childHeight = Math.round((height - totalSpacing) / this._rows);
 
       return themeNode.adjust_preferred_height(height, height);
    }
@@ -40,19 +40,19 @@ class ThumbnailWsmatrixPopupList extends WorkspaceSwitcherPopupList {
       let children = this.get_children();
       let workArea = Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex);
       let themeNode = this.get_theme_node();
+      let spacing = themeNode.get_length('spacing');
 
-      let availWidth = workArea.width;
-      availWidth -= themeNode.get_horizontal_padding();
+      let availWidth = workArea.width - themeNode.get_horizontal_padding();
 
       let width = this._columns * this._scale * children[0].get_width();
-      let spacing = this._itemSpacing * (this._columns - 1);
+      let totalSpacing = spacing * (this._columns - 1);
 
-      width += spacing;
+      width += totalSpacing;
       width = Math.round(Math.min(width, availWidth));
 
-      this._childWidth = Math.round((width - spacing) / this._columns);
+      this._childWidth = Math.round((width - totalSpacing) / this._columns);
 
-      return themeNode.adjust_preferred_height(width, width);
+      return [width, width];
    }
 
    vfunc_allocate(box, flags) {
@@ -60,16 +60,23 @@ class ThumbnailWsmatrixPopupList extends WorkspaceSwitcherPopupList {
 
       let themeNode = this.get_theme_node();
       box = themeNode.get_content_box(box);
+      let spacing = themeNode.get_length('spacing');
 
       let children = this.get_children();
       let childBox = new Clutter.ActorBox();
 
       let row = 0;
       let column = 0;
-      let itemWidth = this._childWidth + this._itemSpacing;
-      let itemHeight = this._childHeight + this._itemSpacing;
-      let indicatorOffset = Math.round(this._itemSpacing / 2);
+      let itemWidth = this._childWidth + spacing;
+      let itemHeight = this._childHeight + spacing;
       let indicator = children.pop();
+
+      let indicatorThemeNode = indicator.get_theme_node();
+
+      let indicatorTopFullBorder = indicatorThemeNode.get_padding(St.Side.TOP) + indicatorThemeNode.get_border_width(St.Side.TOP);
+      let indicatorBottomFullBorder = indicatorThemeNode.get_padding(St.Side.BOTTOM) + indicatorThemeNode.get_border_width(St.Side.BOTTOM);
+      let indicatorLeftFullBorder = indicatorThemeNode.get_padding(St.Side.LEFT) + indicatorThemeNode.get_border_width(St.Side.LEFT);
+      let indicatorRightFullBorder = indicatorThemeNode.get_padding(St.Side.RIGHT) + indicatorThemeNode.get_border_width(St.Side.RIGHT);
 
       for (let i = 0; i < children.length; i++) {
          row = Math.floor(i / this._columns);
@@ -82,10 +89,10 @@ class ThumbnailWsmatrixPopupList extends WorkspaceSwitcherPopupList {
          children[i].allocate(childBox, flags);
 
          if (i === this._activeWorkspaceIndex) {
-            childBox.x1 -= indicatorOffset;
-            childBox.x2 = childBox.x1 + this._childWidth + indicatorOffset * 2;
-            childBox.y1 -= indicatorOffset;
-            childBox.y2 = childBox.y1 + this._childHeight + indicatorOffset * 2;
+            childBox.x2 = childBox.x1 + this._childWidth + indicatorRightFullBorder;
+            childBox.x1 -= indicatorLeftFullBorder;
+            childBox.y2 = childBox.y1 + this._childHeight + indicatorBottomFullBorder;
+            childBox.y1 -= indicatorTopFullBorder;
             indicator.allocate(childBox, flags);
          }
       }

--- a/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
+++ b/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
@@ -14,7 +14,6 @@ var ThumbnailsBoxOverride = class {
       this.thumbnailsBox = thumbnailsBox;
       this.overrideProperties = [
          '_activateThumbnailAtPoint',
-         '_activeWorkspaceChanged',
          'allocate',
          'handleDragOver',
          'get_preferred_height',
@@ -97,31 +96,6 @@ var ThumbnailsBoxOverride = class {
       if (thumbnail) {
          thumbnail.activate(time);
       }
-   }
-
-   // Overriding the Tweener animation to consider both vertical and horizontal changes
-   // the original method only animates vertically
-   _activeWorkspaceChanged(wm, from, to, direction) {
-      let workspaceManager = global.workspace_manager;
-      let activeWorkspace = workspaceManager.get_active_workspace();
-      let thumbnail = this._thumbnails.find(t => t.metaWorkspace == activeWorkspace);
-      let [thumbX, thumbY] = thumbnail.get_position();
-
-      this._animatingIndicator = true;
-
-      //todo: this code should animate x & y, but for some reason it is not
-      this._indicator.ease({
-         thumbX,
-         thumbY,
-         duration: WorkspacesView.WORKSPACE_SWITCH_TIME,
-         mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-         onComplete: () => {
-            this._animatingIndicator = false;
-            this.indicator_x = thumbX;
-            this.indicator_y = thumbY;
-            this._queueUpdateStates();
-         }
-      });
    }
 
    // It is helpful to be able to control the height

--- a/wsmatrix@martin.zurowietz.de/WmOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WmOverride.js
@@ -44,10 +44,10 @@ var WmOverride = class {
 
    destroy() {
       this._destroyWorkspaceSwitcherPopup();
-      this._disconnectSettings();
-      this._restoreKeybindingHandlers();
       this._restoreLayout();
+      this._restoreKeybindingHandlers();
       this._restoreDynamicWorkspaces();
+      this._disconnectSettings();
       this._notify();
       this._removeKeybindings();
       this._disconnectOverview();
@@ -254,8 +254,8 @@ var WmOverride = class {
    _restoreLayout() {
       this.wsManager.override_workspace_layout(
          DisplayWrapper.getDisplayCorner().TOPLEFT, // workspace 0
-         true, // true == lay out in columns. false == lay out in rows
-         this.rows * this.columns,
+         false, // true == lay out in columns. false == lay out in rows
+         -1,
          1
       );
    }

--- a/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
@@ -29,12 +29,13 @@ var WorkspacesDisplayOverride = class {
    // Allow scrolling workspaces in overview to go through rows and columns
    // original code goes only through rows.
    _onScrollEvent(actor, event) {
-      if (!this.actor.mapped)
+      if (!this.mapped) {
          return Clutter.EVENT_PROPAGATE;
+      }
 
-      if (this._workspacesOnlyOnPrimary &&
-         this._getMonitorIndexForEvent(event) != this._primaryIndex)
+      if (this._workspacesOnlyOnPrimary && this._getMonitorIndexForEvent(event) != this._primaryIndex) {
          return Clutter.EVENT_PROPAGATE;
+      }
 
       let workspaceManager = global.workspace_manager;
       let targetIndex = workspaceManager.get_active_workspace_index();
@@ -57,8 +58,10 @@ var WorkspacesDisplayOverride = class {
    }
 
    _onKeyPressEvent(actor, event) {
-      if (!this.actor.mapped)
+      if (!this.mapped) {
          return Clutter.EVENT_PROPAGATE;
+      }
+
       let workspaceManager = global.workspace_manager;
       let targetIndex = workspaceManager.get_active_workspace_index();
 

--- a/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
@@ -29,6 +29,7 @@ var WorkspacesDisplayOverride = class {
       this.overrideProperties.forEach(function (prop) {
          this.workspacesDisplay[prop] = this.workspacesDisplay._overrideProperties[prop];
       }, this);
+      delete this.workspacesDisplay._overrideProperties;
    }
 
    // Allow scrolling workspaces in overview to go through rows and columns

--- a/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesDisplayOverride.js
@@ -29,11 +29,20 @@ var WorkspacesDisplayOverride = class {
    // Allow scrolling workspaces in overview to go through rows and columns
    // original code goes only through rows.
    _onScrollEvent(actor, event) {
+      if (this._swipeTracker.canHandleScrollEvent(event)) {
+         return Clutter.EVENT_PROPAGATE;
+      }
+
       if (!this.mapped) {
          return Clutter.EVENT_PROPAGATE;
       }
 
-      if (this._workspacesOnlyOnPrimary && this._getMonitorIndexForEvent(event) != this._primaryIndex) {
+      if (this._workspacesOnlyOnPrimary &&
+         this._getMonitorIndexForEvent(event) != this._primaryIndex) {
+         return Clutter.EVENT_PROPAGATE;
+      }
+
+      if (!this._canScroll) {
          return Clutter.EVENT_PROPAGATE;
       }
 
@@ -54,6 +63,7 @@ var WorkspacesDisplayOverride = class {
       }
 
       Main.wm.actionMoveWorkspace(workspaceManager.get_workspace_by_index(targetIndex));
+
       return Clutter.EVENT_STOP;
    }
 

--- a/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
@@ -69,28 +69,25 @@ var WorkspacesViewOverride = class {
       let active = workspaceManager.get_active_workspace_index();
       let activeRow = Math.floor(active / this.getColumns());
       let activeColumn = active % this.getColumns();
-
       this._animating = showAnimation;
 
       for (let w = 0; w < this._workspaces.length; w++) {
          let workspace = this._workspaces[w];
-         let workspaceRow = Math.floor(w / this.getColumns());
-         let workspaceColumn = w % this.getColumns();
-
-         workspace.actor.remove_all_transitions();
-
+         workspace.remove_all_transitions();
 
          let params = {};
-         if (this.actor.text_direction == Clutter.TextDirection.RTL) {
-            params.x = (activeColumn - workspaceColumn) * this._fullGeometry.width;
-         } else {
-            params.x = (workspaceColumn - activeColumn) * this._fullGeometry.width;
-         }
-         params.y = (workspaceRow - activeRow) * this._fullGeometry.height;
+         if (workspaceManager.layout_rows == -1)
+            params.y = (w - active) * this._fullGeometry.height;
+         else if (this.text_direction == Clutter.TextDirection.RTL)
+            params.x = (active - w) * this._fullGeometry.width;
+         else
+            params.x = (w - active) * this._fullGeometry.width;
 
          if (showAnimation) {
-            let easeParams = Object.assign(params);
-            
+            let easeParams = Object.assign(params, {
+               duration: workspacesView.WORKSPACE_SWITCH_TIME,
+               mode: Clutter.AnimationMode.EASE_OUT_CUBIC,
+            });
             // we have to call _updateVisibility() once before the
             // animation and once afterwards - it does not really
             // matter which tween we use, so we pick the first one ...
@@ -101,24 +98,9 @@ var WorkspacesViewOverride = class {
                   this._updateVisibility();
                };
             }
-
-            if (workspace.actor.ease === undefined) {
-               //maintain compatibility with gnome prior to 3.34
-               easeParams = Object.assign(params, {
-                  time: workspacesView.WORKSPACE_SWITCH_TIME,
-                  transition: 'easeOutQuad'
-               });
-               Tweener.addTween(workspace.actor, easeParams);
-            }
-            else {
-               easeParams = Object.assign(params, {
-                  duration: workspacesView.WORKSPACE_SWITCH_TIME,
-                  mode: Clutter.AnimationMode.EASE_OUT_QUAD
-               });
-               workspace.actor.ease(easeParams);
-            }
+            workspace.ease(easeParams);
          } else {
-            workspace.actor.set(params);
+            workspace.set(params);
             if (w == 0) {
                this._updateVisibility();
             }

--- a/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
@@ -73,15 +73,18 @@ var WorkspacesViewOverride = class {
 
       for (let w = 0; w < this._workspaces.length; w++) {
          let workspace = this._workspaces[w];
+         let workspaceRow = Math.floor(w / this.getColumns());
+         let workspaceColumn = w % this.getColumns();
+
          workspace.remove_all_transitions();
 
          let params = {};
-         if (workspaceManager.layout_rows == -1)
-            params.y = (w - active) * this._fullGeometry.height;
-         else if (this.text_direction == Clutter.TextDirection.RTL)
-            params.x = (active - w) * this._fullGeometry.width;
-         else
-            params.x = (w - active) * this._fullGeometry.width;
+         if (this.actor.text_direction == Clutter.TextDirection.RTL) {
+            params.x = (activeColumn - workspaceColumn) * this._fullGeometry.width;
+         } else {
+            params.x = (workspaceColumn - activeColumn) * this._fullGeometry.width;
+         }
+         params.y = (workspaceRow - activeRow) * this._fullGeometry.height;
 
          if (showAnimation) {
             let easeParams = Object.assign(params, {

--- a/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
@@ -79,7 +79,7 @@ var WorkspacesViewOverride = class {
          workspace.remove_all_transitions();
 
          let params = {};
-         if (this.actor.text_direction == Clutter.TextDirection.RTL) {
+         if (this.text_direction == Clutter.TextDirection.RTL) {
             params.x = (activeColumn - workspaceColumn) * this._fullGeometry.width;
          } else {
             params.x = (workspaceColumn - activeColumn) * this._fullGeometry.width;

--- a/wsmatrix@martin.zurowietz.de/metadata.json
+++ b/wsmatrix@martin.zurowietz.de/metadata.json
@@ -1,6 +1,6 @@
 
 {
-  "shell-version": ["3.34"],
+  "shell-version": ["3.36"],
   "uuid": "wsmatrix@martin.zurowietz.de",
   "url": "https://github.com/mzur/gnome-shell-wsmatrix",
   "settings-schema": "org.gnome.shell.extensions.wsmatrix-settings",

--- a/wsmatrix@martin.zurowietz.de/stylesheet.css
+++ b/wsmatrix@martin.zurowietz.de/stylesheet.css
@@ -1,3 +1,0 @@
-.wsmatrix.ws-switcher-active-up, .wsmatrix.ws-switcher-active-down {
-   background-image: none;
-}


### PR DESCRIPTION
Resolves #96 

Issues: 
- [x] workspace switching animation in overview #56 & # #70
- [x] workspace indicator in overview is [not animating properly](https://salsa.debian.org/gnome-team/gnome-shell/-/commit/9c1940ef9db50ee693c2f82c8a2a4486bce1a1fe)

