### PR TITLE
GNOME Classic Support

### DIFF
--- a/wsmatrix@martin.zurowietz.de/extension.js
+++ b/wsmatrix@martin.zurowietz.de/extension.js
@@ -1,6 +1,7 @@
 const WsMatrix = imports.misc.extensionUtils.getCurrentExtension();
 const Lang = imports.lang;
 const Meta = imports.gi.Meta;
+const Main = imports.ui.main;
 const Settings = WsMatrix.imports.Settings.Settings;
 const WmOverride = WsMatrix.imports.WmOverride.WmOverride;
 const OverviewOverride = WsMatrix.imports.OverviewOverride.OverviewOverride;
@@ -10,12 +11,16 @@ class WsMatrixExtension {
       let settings = new Settings(WsMatrix.metadata['settings-schema']);
       let keybindings = new Settings(WsMatrix.metadata['keybindings-schema']);
       this.overrideWorkspace = new WmOverride(settings, keybindings);
-      this.overrideOverview = new OverviewOverride(settings, keybindings);
+      if (Main.overview._overview) {
+         this.overrideOverview = new OverviewOverride(settings, keybindings);
+      }
    }
 
    destroy() {
       this.overrideWorkspace.destroy();
-      this.overrideOverview.destroy();
+      if (this.overrideOverview) {
+         this.overrideOverview.destroy();
+      }
    }
 }
 


### PR DESCRIPTION
This disables the overview override if the overview object does not exist (as in GNOME Classic).

Resolves #114