### PR TITLE
Support for gnome shell 3.37.90 (3.38)

### DIFF
--- a/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
+++ b/wsmatrix@martin.zurowietz.de/WorkspacesViewOverride.js
@@ -1,7 +1,6 @@
 const { Clutter } = imports.gi;
 const workspacesView = imports.ui.workspacesView;
 const WorkspacesView = workspacesView.WorkspacesView;
-const Tweener = imports.ui.tweener;
 
 var WorkspacesViewOverride = class {
    constructor(settings) {


### PR DESCRIPTION
Tweener was removed and replaced with Clutter's implicit animations since gnome shell 3.37.1, and while 0750ff6153f91cc88c4cc22a787bddcbb7703dc2 updated already depracated by then animation code, it left out the import itself.

This results in incompatibility with gnome 3.37.90 and is not used anywhere, so remove it from the code for good.