### PR TITLE
Updated README. Extra explanation to enable extension 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ The easiest way to install this extension is via the [GNOME Shell Extensions](ht
 Alternatives:
 
 - Download the ZIP file of the [latest release](https://github.com/mzur/gnome-shell-wsmatrix/releases) and extract it to `~/.local/share/gnome-shell/extensions/`.
-
+   ```
+   mkdir -p ~/.local/share/gnome-shell/extensions/wsmatrix@martin.zurowietz.de
+   unzip -q Downloads/wsmatrixmartin.zurowietz.de.v23.shell-extension.zip -d ~/.local/share/gnome-shell/extensions/wsmatrix@martin.zurowietz.de/
+   gnome-extensions enable wsmatrix@martin.zurowietz.de 
+   ```
+   Finally, restart GNOME by pressing <kbd>Alt</kbd>+<kbd>F2</kbd> and running the command `r` (X.org) or log out and back in (Wayland).
 - On Arch Linux you can use [this AUR](https://aur.archlinux.org/packages/gnome-shell-extension-workspace-matrix):
    ```
    git clone https://aur.archlinux.org/gnome-shell-extension-workspace-matrix.git

--- a/README.md
+++ b/README.md
@@ -31,13 +31,7 @@ The easiest way to install this extension is via the [GNOME Shell Extensions](ht
 
 Alternatives:
 
-- Download the ZIP file of the [latest release](https://github.com/mzur/gnome-shell-wsmatrix/releases) and extract it to `~/.local/share/gnome-shell/extensions/`.
-   ```
-   mkdir -p ~/.local/share/gnome-shell/extensions/wsmatrix@martin.zurowietz.de
-   unzip -q Downloads/wsmatrixmartin.zurowietz.de.v23.shell-extension.zip -d ~/.local/share/gnome-shell/extensions/wsmatrix@martin.zurowietz.de/
-   gnome-extensions enable wsmatrix@martin.zurowietz.de 
-   ```
-   Finally, restart GNOME by pressing <kbd>Alt</kbd>+<kbd>F2</kbd> and running the command `r` (X.org) or log out and back in (Wayland).
+- Download the ZIP file of the [latest release](https://github.com/mzur/gnome-shell-wsmatrix/releases) and extract it to `~/.local/share/gnome-shell/extensions/wsmatrix@martin.zurowietz.de`. Then, restart GNOME by pressing <kbd>Alt</kbd>+<kbd>F2</kbd> and running the command `r` (X.org) or log out and back in (Wayland).
 - On Arch Linux you can use [this AUR](https://aur.archlinux.org/packages/gnome-shell-extension-workspace-matrix):
    ```
    git clone https://aur.archlinux.org/gnome-shell-extension-workspace-matrix.git

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The easiest way to install this extension is via the [GNOME Shell Extensions](ht
 
 Alternatives:
 
-- Download the ZIP file of the [latest release](https://github.com/mzur/gnome-shell-wsmatrix/releases) and extract it to `~/.local/share/gnome-shell/extensions/wsmatrix@martin.zurowietz.de`. Then, restart GNOME by pressing <kbd>Alt</kbd>+<kbd>F2</kbd> and running the command `r` (X.org) or log out and back in (Wayland).
+- Download the ZIP file of the [latest release](https://github.com/mzur/gnome-shell-wsmatrix/releases) and extract it to `~/.local/share/gnome-shell/extensions/wsmatrix@martin.zurowietz.de`. Then, run `gnome-extensions enable wsmatrix@martin.zurowietz.de` and restart GNOME by pressing <kbd>Alt</kbd>+<kbd>F2</kbd> and running the command `r` (X.org) or log out and back in (Wayland).
 - On Arch Linux you can use [this AUR](https://aur.archlinux.org/packages/gnome-shell-extension-workspace-matrix):
    ```
    git clone https://aur.archlinux.org/gnome-shell-extension-workspace-matrix.git


### PR DESCRIPTION
Added an extra explanation to enable the extension when downloading from GNOME Shell Extensions website or releases folder using the gnome-extensions tool.