### PR TITLE
Gnome 3.38 fix DnD from current workspace (activity overview) to a workspace thumbnail

### DIFF
--- a/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
+++ b/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
@@ -289,7 +289,7 @@ var ThumbnailsBoxOverride = class {
 
    // Handle dragging a window into a workspace
    handleDragOver(source, actor, x, y, time) {
-      if (!source.realWindow &&
+      if (!source.metaWindow &&
          (!source.app || !source.app.can_open_new_window()) &&
          (source.app || !source.shellWorkspaceLaunch) &&
          source != Main.xdndHandler)
@@ -343,7 +343,7 @@ var ThumbnailsBoxOverride = class {
       if (this._dropWorkspace != -1)
          return this._thumbnails[this._dropWorkspace].handleDragOverInternal(source, actor, time);
       else if (this._dropPlaceholderPos != -1)
-         return source.realWindow ? DND.DragMotionResult.MOVE_DROP : DND.DragMotionResult.COPY_DROP;
+         return source.metaWindow ? DND.DragMotionResult.MOVE_DROP : DND.DragMotionResult.COPY_DROP;
       else
          return DND.DragMotionResult.CONTINUE;
    }

--- a/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
+++ b/wsmatrix@martin.zurowietz.de/ThumbnailsBoxOverride.js
@@ -1,9 +1,7 @@
 const Main = imports.ui.main;
 const WorkspaceThumbnail = imports.ui.workspaceThumbnail;
-const ThumbnailsBox = WorkspaceThumbnail.ThumbnailsBox;
 const { Clutter, St, Meta } = imports.gi;
 const DND = imports.ui.dnd;
-const WorkspacesView = imports.ui.workspacesView;
 const MAX_THUMBNAIL_SCALE = 1 / 10.;
 const MAX_HORIZONTAL_THUMBNAIL_SCALE = 0.4;
 


### PR DESCRIPTION
This PR is to address https://github.com/mzur/gnome-shell-wsmatrix/issues/143.

DnD of a window at the center of the activity overview (a window from the current workspace) to a workspace thumbnail does not work in Gnome 3.38. The checking logic to see if the DnD is in progress (returning `DND.DragMotionResult.CONTINUE`) returns false positive, due to `source.realWindow` always return `undefined` when dragging a window in activity overview to a workspace thumbnail.

### Changes:
- Change DnD checking in `handleDragOver()` from checking `source.realWindow` to `source.metaWindow`. This is inline with `gnome-shell` upstream change (https://github.com/GNOME/gnome-shell/commit/46600740fedd6da7344d4693fb8b0721ef063d0c),
- Remove unused imports.
