### PR TITLE
fix modifier mask captures reserved modifiers

### DIFF
--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
@@ -449,7 +449,7 @@ var WorkspaceManagerOverride = class {
                     });
 
                     let event = Clutter.get_current_event();
-                    let modifiers = event ? event.get_state() : 0;
+                    let modifiers = event ? event.get_state() & Clutter.ModifierType.MODIFIER_MASK : 0;
                     this.wm._wsPopupList[monitorIndex].showToggle(false, null, modifiers, toggle);
                     if (monitorIndex === Main.layoutManager.primaryIndex) {
                         this.wm._workspaceSwitcherPopup = this.wm._wsPopupList[monitorIndex];


### PR DESCRIPTION
Sometimes for a very unknown reason, `GNOME` adds reserved modifiers to the event retrieved from `Clutter.get_current_event().get_state()`. This causes an incorrect modifier mask to be calculated and a blink behavior if the `popup timeout` is 0.

To resolve this issue, we need to and the `Clutter.get_current_event().get_state()` with `Clutter.ModifierType.MODIFIER_MASK` which is a mask the contains a number to clear all the flags of the reserved modifiers.

reference: https://valadoc.org/clutter-1.0/Clutter.ModifierType.html

``
Note that Clutter may add internal values to events which include reserved values such as MODIFIER_RESERVED_13_MASK. Your code should preserve and ignore them. You can use MODIFIER_MASK to remove all reserved values.
``