### PR TITLE
Remove switcher timeout on destroy

### DIFF
--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopup.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopup.js
@@ -22,6 +22,7 @@ class WorkspaceSwitcherPopup extends SwitcherPopup.SwitcherPopup {
         this._items = this._createThumbnails();
         this._switcherList = new WorkspaceSwitcherPopupList.WorkspaceSwitcherPopupList(this._items, this._createLabels(), options);
         this._overviewKeybindingActions = options.overveiwKeybindingActions;
+        this._noModsTimeoutId = 0;
 
         // Initially disable hover so we ignore the enter-event if
         // the switcher appears underneath the current pointer location
@@ -196,7 +197,13 @@ class WorkspaceSwitcherPopup extends SwitcherPopup.SwitcherPopup {
     }
 
     _onDestroy() {
+        if (this._noModsTimeoutId != 0) {
+            GLib.source_remove(this._noModsTimeoutId);
+            this._noModsTimeoutId = 0;
+        }
+
         super._onDestroy();
+
         while (modals.length > 0) {
             modals.pop().destroy();
         }


### PR DESCRIPTION
This was requested by the reviewers of extensions.gnome.org although
the timeout is also removed in super._onDestroy().

References https://extensions.gnome.org/review/28844