### PR TITLE
Fix actionMoveWindow getting null window

### DIFF
--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
@@ -411,14 +411,27 @@ var WorkspaceManagerOverride = class {
         }
 
         if (newWs !== undefined) {
-            if (action == 'switch')
+            if (action == 'switch') {
                 this.wm.actionMoveWorkspace(newWs);
-            else
+                this._showWorkspaceSwitcherPopup(false);
+            } else {
+                this.monitors.forEach((monitor) => {
+                    let monitorIndex = monitor.index;
+                    if (this.wm._wsPopupList[monitorIndex]) {
+                        if (monitorIndex === Main.layoutManager.primaryIndex) {
+                            this.wm._wsPopupList[monitorIndex].resetTimeout();
+                        }
+                    } else {
+                        // console.warn("derp")
+                        this._showWorkspaceSwitcherPopup(false);
+                    }
+                });
                 this.wm.actionMoveWindow(window, newWs);
+            }
         }
 
-        this._showWorkspaceSwitcherPopup(false);
     }
+
 
     _showWorkspaceSwitcherPopup(toggle) {
         if (Main.overview.visible) {

--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
@@ -415,17 +415,7 @@ var WorkspaceManagerOverride = class {
                 this.wm.actionMoveWorkspace(newWs);
                 this._showWorkspaceSwitcherPopup(false);
             } else {
-                this.monitors.forEach((monitor) => {
-                    let monitorIndex = monitor.index;
-                    if (this.wm._wsPopupList[monitorIndex]) {
-                        if (monitorIndex === Main.layoutManager.primaryIndex) {
-                            this.wm._wsPopupList[monitorIndex].resetTimeout();
-                        }
-                    } else {
-                        // console.warn("derp")
-                        this._showWorkspaceSwitcherPopup(false);
-                    }
-                });
+                this._showWorkspaceSwitcherPopup(false);
                 this.wm.actionMoveWindow(window, newWs);
             }
         }


### PR DESCRIPTION
As mentioned in #245.

` _showWorkspaceSwitcherPopup` must be called before `actionMoveWindow` otherwise the latter will get a null window object, locking any further window movement to after the switcher popup is destroyed.