### PR TITLE
GNOME: add support for version 44

### DIFF
--- a/wsmatrix@martin.zurowietz.de/metadata.json
+++ b/wsmatrix@martin.zurowietz.de/metadata.json
@@ -1,7 +1,6 @@
 {
     "shell-version": [
-        "42",
-        "43"
+        "44"
     ],
     "uuid": "wsmatrix@martin.zurowietz.de",
     "url": "https://github.com/mzur/gnome-shell-wsmatrix",

--- a/wsmatrix@martin.zurowietz.de/overview/thumbnailsBox.js
+++ b/wsmatrix@martin.zurowietz.de/overview/thumbnailsBox.js
@@ -184,7 +184,8 @@ var ThumbnailsBox = class {
                     this._dropPlaceholder.allocate_preferred_size(
                         ...this._dropPlaceholder.get_position());
 
-                    Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
+                    const laters = global.compositor.get_laters();
+                    laters.add(Meta.LaterType.BEFORE_REDRAW, () => {
                         this._dropPlaceholder.hide();
                     });
                 }
@@ -219,7 +220,8 @@ var ThumbnailsBox = class {
 
                         this._dropPlaceholder.allocate(childBox);
 
-                        Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
+                        const laters = global.compositor.get_laters();
+                        laters.add(Meta.LaterType.BEFORE_REDRAW, () => {
                             this._dropPlaceholder.show();
                         });
                         x += placeholderWidth + spacing;


### PR DESCRIPTION
First, thank you for maintaining this very useful add-on!

When using GNOME 44 beta (`44~beta-1ubuntu1` on Ubuntu 23.04), I got this warning after having forced version 44 support in `metadata.js`:

```
JS ERROR: TypeError: Meta.later_add is not a function
vfunc_allocate@${HOME}/.local/share/gnome-shell/extensions/wsmatrix@martin.zurowietz.de/overview/thumbnailsBox.js:187:26
vfunc_allocate@resource:///org/gnome/shell/ui/overviewControls.js:195:40
_prepareMainDash/<@/usr/share/gnome-shell/extensions/ubuntu-dock@ubuntu.com/docking.js:2264:22
_hideDone@resource:///org/gnome/shell/ui/overview.js:632:25
_animateNotVisible/<@resource:///org/gnome/shell/ui/overview.js:625:55
onStopped@resource:///org/gnome/shell/ui/overviewControls.js:771:21
_makeEaseCallback/<@resource:///org/gnome/shell/ui/environment.js:151:22
_easeActorProperty/<@resource:///org/gnome/shell/ui/environment.js:317:60
```

I simply applied the same fix as this one: https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/8d68bdaaa163

I guess this modification breaks the compatibility with older versions but I didn't investigate more.

Apart from that, the rest seems working fine, tested on Wayland only.