### PR TITLE
Minor changes for gnome 46. Overview not working!

### DIFF
--- a/wsmatrix@martin.zurowietz.de/metadata.json
+++ b/wsmatrix@martin.zurowietz.de/metadata.json
@@ -1,6 +1,6 @@
 {
     "shell-version": [
-        "45"
+        "46"
     ],
     "uuid": "wsmatrix@martin.zurowietz.de",
     "url": "https://github.com/mzur/gnome-shell-wsmatrix",

--- a/wsmatrix@martin.zurowietz.de/overview/controlsManagerLayout.js
+++ b/wsmatrix@martin.zurowietz.de/overview/controlsManagerLayout.js
@@ -5,8 +5,7 @@ import {SMALL_WORKSPACE_RATIO, ControlsState} from 'resource:///org/gnome/shell/
 const _computeWorkspacesBoxForState = function(state, box, searchHeight, dashHeight, thumbnailsHeight) {
     const workspaceBox = box.copy();
     const [width, height] = workspaceBox.get_size();
-    const { y1: startY } = this._workAreaBox;
-    const {spacing} = this;
+    const {y1: startY} = this._workAreaBox;
     const {expandFraction} = this._workspacesThumbnails;
 
     const workspaceManager = global.workspace_manager;
@@ -19,16 +18,16 @@ const _computeWorkspacesBoxForState = function(state, box, searchHeight, dashHei
         break;
     case ControlsState.WINDOW_PICKER:
         workspaceBox.set_origin(0,
-            startY + searchHeight + spacing +
-            thumbnailsHeight * rows + spacing * expandFraction);
+            startY + searchHeight + this._spacing +
+            thumbnailsHeight * rows + this._spacing * expandFraction);
         workspaceBox.set_size(width,
             height -
-            dashHeight - spacing -
-            searchHeight - spacing -
-            thumbnailsHeight * rows - spacing * expandFraction);
+            dashHeight - this._spacing -
+            searchHeight - this._spacing -
+            thumbnailsHeight * rows - this._spacing * expandFraction);
         break;
     case ControlsState.APP_GRID:
-        workspaceBox.set_origin(0, startY + searchHeight + spacing);
+        workspaceBox.set_origin(0, startY + searchHeight + this._spacing);
         workspaceBox.set_size(
             width,
             Math.round(height * rows * SMALL_WORKSPACE_RATIO));

--- a/wsmatrix@martin.zurowietz.de/overview/overviewManager.js
+++ b/wsmatrix@martin.zurowietz.de/overview/overviewManager.js
@@ -7,23 +7,17 @@ import {PACKAGE_VERSION} from 'resource:///org/gnome/shell/misc/config.js';
 export default class OverviewManager {
     constructor(settings) {
         this._settings = settings;
-    }
-
-    async enable() {
-        this._connectSettings();
-        await this._initOverrides();
-        this._handleShowOverviewGridChanged();
-    }
-
-    // This can be moved to the constructor again if there is no need for the conditional
-    // import any more.
-    async _initOverrides() {
         this._overrides = [
             new WorkspacesView(),
             new SecondaryMonitorDisplay(),
             new ThumbnailsBox(),
             new ControlsManagerLayout(),
         ];
+    }
+
+    enable() {
+        this._connectSettings();
+        this._handleShowOverviewGridChanged();
     }
 
     _connectSettings() {

--- a/wsmatrix@martin.zurowietz.de/overview/overviewManager.js
+++ b/wsmatrix@martin.zurowietz.de/overview/overviewManager.js
@@ -1,8 +1,7 @@
-// import ControlsManagerLayout from './controlsManagerLayout.js';
+import ControlsManagerLayout from './controlsManagerLayout.js';
 import SecondaryMonitorDisplay from './secondaryMonitorDisplay.js';
-// import ThumbnailsBox from './thumbnailsBox.js';
+import ThumbnailsBox from './thumbnailsBox.js';
 import WorkspacesView from './workspacesView.js';
-import {GNOMEversionCompare} from 'resource:///org/gnome/shell/misc/util.js';
 import {PACKAGE_VERSION} from 'resource:///org/gnome/shell/misc/config.js';
 
 export default class OverviewManager {
@@ -22,17 +21,9 @@ export default class OverviewManager {
         this._overrides = [
             new WorkspacesView(),
             new SecondaryMonitorDisplay(),
-            // new ThumbnailsBox(),
-            // new ControlsManagerLayout(),
+            new ThumbnailsBox(),
+            new ControlsManagerLayout(),
         ];
-
-        // This only works starting in GNOME Shell 45.1 and up.
-        if (GNOMEversionCompare(PACKAGE_VERSION, '45.1') >= 0) {
-            const {default: ThumbnailsBox} = await import('./thumbnailsBox.js');
-            this._overrides.push(new ThumbnailsBox());
-            const {default: ControlsManagerLayout} = await import('./controlsManagerLayout.js');
-            this._overrides.push(new ControlsManagerLayout());
-        }
     }
 
     _connectSettings() {

--- a/wsmatrix@martin.zurowietz.de/overview/thumbnailsBox.js
+++ b/wsmatrix@martin.zurowietz.de/overview/thumbnailsBox.js
@@ -105,10 +105,8 @@ const vfunc_allocate = function(box) {
 
     let rtl = Clutter.get_default_text_direction() == Clutter.TextDirection.RTL;
 
-    if (this._thumbnails.length == 0) {
-        // not visible
-        return;
-    }
+    if (this._thumbnails.length === 0) // not visible
+            return;
 
     let themeNode = this.get_theme_node();
     box = themeNode.get_content_box(box);

--- a/wsmatrix@martin.zurowietz.de/overview/thumbnailsBox.js
+++ b/wsmatrix@martin.zurowietz.de/overview/thumbnailsBox.js
@@ -19,7 +19,7 @@ const addThumbnails = function (start, count) {
             this._porthole.x, this._porthole.y,
             this._porthole.width, this._porthole.height);
         this._thumbnails.push(thumbnail);
-        this.add_actor(thumbnail);
+        this.add_child(thumbnail);
 
         if (this._shouldShow && start > 0 && this._spliceIndex === -1) {
             // not the initial fill, and not splicing via DND

--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
@@ -5,17 +5,9 @@ import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
 import WorkspaceSwitcherPopup from "./workspaceSwitcherPopup.js";
-// import {SCROLL_TIMEOUT_TIME} from 'resource:///org/gnome/shell/ui/windowManager.js';
-// import {WorkspaceAnimationController} from "./workspaceAnimation.js";
-import {GNOMEversionCompare} from 'resource:///org/gnome/shell/misc/util.js';
+import {SCROLL_TIMEOUT_TIME} from 'resource:///org/gnome/shell/ui/windowManager.js';
+import {WorkspaceAnimationController} from "./workspaceAnimation.js";
 import {PACKAGE_VERSION} from 'resource:///org/gnome/shell/misc/config.js';
-
-let SCROLL_TIMEOUT_TIME = 150;
-if (GNOMEversionCompare(PACKAGE_VERSION, '45.1') >= 0) {
-    import('resource:///org/gnome/shell/ui/windowManager.js').then((mod) => {
-        SCROLL_TIMEOUT_TIME = mod.SCROLL_TIMEOUT_TIME;
-    });
-}
 
 const WraparoundMode = {
     NONE: 0,
@@ -36,11 +28,15 @@ export default class WorkspaceManagerOverride {
         this._keybindings = keybindings;
         this._overviewKeybindingActions = {};
         this.monitors = [];
+
+        this._workspaceAnimation = new WorkspaceAnimationController();
+        this.overrideProperties = [
+            '_workspaceAnimation',
+            'handleWorkspaceScroll',
+        ];
     }
 
-    async enable() {
-        await this._initOverrides()
-
+    enable() {
         this._overrideDynamicWorkspaces();
         this._overrideKeybindingHandlers();
         this._overrideOriginalProperties();
@@ -51,23 +47,6 @@ export default class WorkspaceManagerOverride {
         this._notify();
         this._addKeybindings();
         this._connectLayoutManager();
-    }
-
-    // This can be moved to the constructor again if there is no need for the conditional
-    // import any more.
-    async _initOverrides() {
-        // this._workspaceAnimation = new WorkspaceAnimationController();
-        this.overrideProperties = [
-            // '_workspaceAnimation',
-            'handleWorkspaceScroll',
-        ];
-
-        // This only works starting in GNOME Shell 45.1 and up.
-        if (GNOMEversionCompare(PACKAGE_VERSION, '45.1') >= 0) {
-            const {WorkspaceAnimationController} = await import("./workspaceAnimation.js");
-            this._workspaceAnimation = new WorkspaceAnimationController();
-            this.overrideProperties.push('_workspaceAnimation');
-        }
     }
 
     disable() {

--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopupList.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopupList.js
@@ -63,7 +63,7 @@ export default GObject.registerClass({
                 this.redisplay();
             });
 
-            this.add_actor(workspacesRow);
+            this.add_child(workspacesRow);
             this._lists.push(workspacesRow);
         }
 
@@ -113,7 +113,7 @@ export default GObject.registerClass({
         }
 
         bbox.set_child(container);
-        list.add_actor(bbox);
+        list.add_child(bbox);
 
         bbox.connect('clicked', () => this._onItemClicked(bbox));
         bbox.connect('motion-event', () => this._onItemEnter(bbox));

--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopupList.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopupList.js
@@ -169,12 +169,12 @@ export default GObject.registerClass({
 
     highlight(index, justOutline) {
         if (this._items[this._highlighted]) {
-            this._items[this._highlighted].remove_style_pseudo_class('outlined');
+            this._items[this._highlighted].remove_style_pseudo_class('highlighted');
             this._items[this._highlighted].remove_style_pseudo_class('selected');
         }
 
         if (this._items[index]) {
-            this._items[index].add_style_pseudo_class(justOutline ? 'outlined' : 'selected');
+            this._items[index].add_style_pseudo_class(justOutline ? 'highlighted' : 'selected');
         }
 
         this._highlighted = index;


### PR DESCRIPTION
Very preliminary and partial solution for #276 

I don’t have a good understanding for how it all works, but these changes enabled me to run it. However, overview is not working and results in these errors. Couldn’t understand why.

```
mar 28 09:51:20 ajla gnome-shell[18550]: _st_create_shadow_pipeline_from_actor: assertion 'clutter_actor_has_allocation (actor)' failed
mar 28 09:51:20 ajla gnome-shell[18550]: _st_create_shadow_pipeline_from_actor: assertion 'clutter_actor_has_allocation (actor)' failed
mar 28 09:51:20 ajla gnome-shell[18550]: _st_create_shadow_pipeline_from_actor: assertion 'clutter_actor_has_allocation (actor)' failed
mar 28 09:51:20 ajla gnome-shell[18550]: _st_create_shadow_pipeline_from_actor: assertion 'clutter_actor_has_allocation (actor)' failed
mar 28 09:51:20 ajla gnome-shell[18550]: Can't update stage views actor unnamed [ClutterActor] is on because it needs an allocation.
mar 28 09:51:20 ajla gnome-shell[18550]: Can't update stage views actor unnamed [StIcon] is on because it needs an allocation.
mar 28 09:51:20 ajla gnome-shell[18550]: Can't update stage views actor unnamed [ClutterActor] is on because it needs an allocation.
mar 28 09:51:20 ajla gnome-shell[18550]: Can't update stage views actor unnamed [StIcon] is on because it needs an allocation.
mar 28 09:51:20 ajla gnome-shell[18550]: Can't update stage views actor unnamed [ClutterActor] is on because it needs an allocation.
mar 28 09:51:20 ajla gnome-shell[18550]: Can't update stage views actor unnamed [StIcon] is on because it needs an allocation.
mar 28 09:51:20 ajla gnome-shell[18550]: Can't update stage views actor unnamed [ClutterActor] is on because it needs an allocation.
mar 28 09:51:20 ajla gnome-shell[18550]: Can't update stage views actor unnamed [StIcon] is on because it needs an allocation.
mar 28 09:51:20 ajla gnome-shell[18550]: clutter_actor_allocate: assertion '!isnan (real_allocation.x1) && !isnan (real_allocation.x2) && !isnan (real_allocat>
```

I don’t use overview much, and disabling it in settings avoids the errors.