### PR TITLE
Don't leak WorkspaceThumbnail objects

### DIFF
--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopup.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopup.js
@@ -195,6 +195,9 @@ class WorkspaceSwitcherPopup extends SwitcherPopup {
         while (modals.length > 0) {
             modals.pop().destroy();
         }
+
+        this._items.forEach((x) => x.destroy());
+        this._items = [];
     }
 
     vfunc_allocate(box) {

--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopupList.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopupList.js
@@ -42,8 +42,6 @@ export default GObject.registerClass({
             style: `spacing: ${ITEM_SPACING}`,
         });
         this._lists = [];
-        this._thumbnails = thumbnails;
-        this._workspaceName = workspaceName;
         this._scale = options.scale;
         this._showThumbnails = options.showThumbnails;
         this._showWorkspaceName = options.showWorkspaceNames;
@@ -75,7 +73,7 @@ export default GObject.registerClass({
                 () => this.highlight(workspaceManager.get_active_workspace_index()));
 
         for (let i = 0; i < thumbnails.length; i++) {
-            this.addItem(this._thumbnails[i], this._workspaceName[i]);
+            this.addItem(thumbnails[i], workspaceName[i]);
         }
     }
 


### PR DESCRIPTION
From the main commit:
```
WorkspaceThumbnail objects must be explicitly destroy()ed, otherwise
they will not be garbage collected. Furthermore, each such object
subscribes to the "window-{left,entered}-monitor" signal of the
particular MetaDisplay. Thus leaking these thumbnails causes those
signals to have a very large number of subscribers after the popup
has been shown a sufficient number of times. This shows up in profiling,
and also causes stuttering when a window is moved between monitors or created.

For example, with 4*4=16 workspaces on 3 monitors, every time the popup
is shown 48 new subscribers are added to both signals. After a couple
days of uptime, there may be thousands.

Fix that by destroying the WorkspaceThumbnail objects in `_onDestroy()`.
```