### PR TITLE
GNOME: add support for version 48

### DIFF
--- a/wsmatrix@martin.zurowietz.de/metadata.json
+++ b/wsmatrix@martin.zurowietz.de/metadata.json
@@ -1,6 +1,6 @@
 {
     "shell-version": [
-		"47"
+		"48"
     ],
     "uuid": "wsmatrix@martin.zurowietz.de",
     "url": "https://github.com/mzur/gnome-shell-wsmatrix",

--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceAnimation.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceAnimation.js
@@ -251,6 +251,6 @@ export class WorkspaceAnimationController extends GWorkspaceAnimationController 
             switchData.monitors.push(group);
         }
 
-        Meta.disable_unredirect_for_display(global.display);
+        global.compositor.disable_unredirect();
     }
 }

--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceManagerOverride.js
@@ -380,7 +380,7 @@ export default class WorkspaceManagerOverride {
      * directions and using the WorkspaceSwitcherPopup (with constructor arguments)
      * provided by this extension.
      */
-    _showWorkspaceSwitcher(display, window, binding) {
+    _showWorkspaceSwitcher(display, window, event, binding) {
         let workspaceManager = this.wsManager;
 
         if (!Main.sessionMode.hasWorkspaces)

--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopup.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceSwitcherPopup.js
@@ -170,7 +170,7 @@ class WorkspaceSwitcherPopup extends SwitcherPopup {
                     key = 'move-to-workspace-' + key.replace('move_to_workspace_', '');
                 }
 
-                this._wm._showWorkspaceSwitcher(global.display, global.display.focus_window, key);
+                this._wm._showWorkspaceSwitcher(global.display, global.display.focus_window, null, key);
             }
         }
 


### PR DESCRIPTION
First, thank you for this great extension!

The extension was loading fine with GNOME Shell 48, but then I was unable to switch between workspaces. `journalctl -f /usr/bin/gnome-shell` was showing some errors.

The upgrading instructions [1] mentioned that:

- `_showWorkspaceSwitcher` has a new 3rd argument: event, currently unused from what I see [2].

- `Meta.disable_unredirect_for_display` has been renamed and moved to a new namespace: `Meta.Compositor.disable_unredirect`.

- We can get the `Meta.Compositor` using `global.compositor`.

With these modifications, it looks like the extension can continue to work on GNOME v48.

The minimum GNOME version is now 48.

Link: https://gjs.guide/extensions/upgrading/gnome-shell-48.html [1]
Link: https://github.com/GNOME/gnome-shell/blob/48.beta/js/ui/windowManager.js#L1747-L1846 [2]