### PR TITLE
uses accent colour in the workspace selector

### DIFF
--- a/wsmatrix@martin.zurowietz.de/stylesheet.css
+++ b/wsmatrix@martin.zurowietz.de/stylesheet.css
@@ -1,0 +1,3 @@
+.item-box:selected {
+    background-color: -st-accent-color;
+}


### PR DESCRIPTION
sort of addresses #226 – doesn't make it configurable but it's better than the default.