### PR TITLE
Make the workspace grid fully usable in the overview (drag-drop, click, layout, switch animation)

### DIFF
--- a/wsmatrix@martin.zurowietz.de/overview/controlsManagerLayout.js
+++ b/wsmatrix@martin.zurowietz.de/overview/controlsManagerLayout.js
@@ -17,14 +17,16 @@ const _computeWorkspacesBoxForState = function(state, box, searchHeight, dashHei
         workspaceBox.set_size(...this._workAreaBox.get_size());
         break;
     case ControlsState.WINDOW_PICKER:
+        // thumbnailsHeight already covers all grid rows (see the patched
+        // vfunc_get_preferred_height), so do not multiply by rows again.
         workspaceBox.set_origin(0,
             startY + searchHeight + spacing +
-            thumbnailsHeight * rows + spacing * expandFraction);
+            thumbnailsHeight + spacing * expandFraction);
         workspaceBox.set_size(width,
             height -
             dashHeight - spacing -
             searchHeight - spacing -
-            thumbnailsHeight * rows - spacing * expandFraction);
+            thumbnailsHeight - spacing * expandFraction);
         break;
     case ControlsState.APP_GRID:
         workspaceBox.set_origin(0, startY + searchHeight + spacing);

--- a/wsmatrix@martin.zurowietz.de/overview/thumbnailsBox.js
+++ b/wsmatrix@martin.zurowietz.de/overview/thumbnailsBox.js
@@ -60,7 +60,11 @@ const vfunc_get_preferred_height = function (forWidth) {
     let scale = (avail / columns) / this._porthole.width;
     scale = Math.min(scale, this._maxThumbnailScale);
 
-    const height = Math.round(this._porthole.height * scale);
+    // Thumbnails are laid out in a grid, so the preferred height must cover ALL
+    // rows. Otherwise GNOME allocates the box one row tall and the lower rows,
+    // drawn outside the box, never receive clicks.
+    const rowHeight = Math.round(this._porthole.height * scale);
+    const height = rowHeight * rows;
     return themeNode.adjust_preferred_height(height, height);
 }
 
@@ -122,7 +126,11 @@ const vfunc_allocate = function(box) {
         const availableWidth = (box.get_width() - totalSpacing) / columns;
 
         const hScale = availableWidth / portholeWidth;
-        const vScale = box.get_height() / portholeHeight;
+        // hScale divides by columns (availableWidth); vScale must divide by rows,
+        // otherwise thumbnails are sized as if the box held a single row and the
+        // grid overflows vertically (lower rows get cropped).
+        const availableHeight = box.get_height() / rows;
+        const vScale = availableHeight / portholeHeight;
         const newScale = Math.min(hScale, vScale);
 
         if (newScale !== this._targetScale) {
@@ -288,9 +296,150 @@ const vfunc_allocate = function(box) {
     this._indicator.allocate(childBox);
 }
 
+// Drag-and-drop onto lower grid rows.
+//
+// wsmatrix lays the workspaces out in a 2D grid, but GNOME's drop-target
+// detection only tests the X coordinate (_withinWorkspace / _getPlaceholderTarget).
+// In a grid every column shares the same X range across all of its rows, and
+// handleDragOver stops at the first matching index, so a drop always lands on the
+// top-row thumbnail. Only the top row works.
+// (https://github.com/mzur/gnome-shell-wsmatrix/issues/274)
+//
+// Fix: remember the pointer Y in handleDragOver, then add a "is the thumbnail in
+// the right row?" test to both helpers. The original X logic still picks the column.
+
+// Upstream constant (resource:///org/gnome/shell/ui/workspaceThumbnail.js).
+const WORKSPACE_CUT_SIZE = 10;
+
+// True if the drag Y falls within this thumbnail's vertical band (its row).
+const withinRow = function (index) {
+    const y = this._wsmatrixDragY;
+    if (y === undefined)
+        return true; // no recorded drag position -> don't block
+    const workspace = this._thumbnails[index];
+    return y > workspace.y && y <= workspace.y + workspace.height;
+};
+
+// Reimplements upstream _withinWorkspace with an added per-row filter.
+const _withinWorkspace = function (x, index, rtl) {
+    if (!withinRow.call(this, index))
+        return false;
+
+    const length = this._thumbnails.length;
+    const workspace = this._thumbnails[index];
+
+    let workspaceX1 = workspace.x + WORKSPACE_CUT_SIZE;
+    let workspaceX2 = workspace.x + workspace.width - WORKSPACE_CUT_SIZE;
+
+    if (index === length - 1) {
+        if (rtl)
+            workspaceX1 -= WORKSPACE_CUT_SIZE;
+        else
+            workspaceX2 += WORKSPACE_CUT_SIZE;
+    }
+
+    return x > workspaceX1 && x <= workspaceX2;
+};
+
+// Reimplements upstream _getPlaceholderTarget with an added per-row filter:
+// outside the right row, return an impossible range so it never matches.
+const _getPlaceholderTarget = function (index, spacing, rtl) {
+    if (!withinRow.call(this, index))
+        return [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY];
+
+    const workspace = this._thumbnails[index];
+
+    let targetX1;
+    let targetX2;
+
+    if (rtl) {
+        const baseX = workspace.x + workspace.width;
+        targetX1 = baseX - WORKSPACE_CUT_SIZE;
+        targetX2 = baseX + spacing + WORKSPACE_CUT_SIZE;
+    } else {
+        targetX1 = workspace.x - spacing - WORKSPACE_CUT_SIZE;
+        targetX2 = workspace.x + WORKSPACE_CUT_SIZE;
+    }
+
+    if (index === 0) {
+        if (rtl)
+            targetX2 -= spacing + WORKSPACE_CUT_SIZE;
+        else
+            targetX1 += spacing + WORKSPACE_CUT_SIZE;
+    }
+
+    if (index === this._dropPlaceholderPos) {
+        const placeholderWidth = this._dropPlaceholder.get_width() + spacing;
+        if (rtl)
+            targetX2 += placeholderWidth;
+        else
+            targetX1 -= placeholderWidth;
+    }
+
+    return [targetX1, targetX2];
+};
+
+// Workspace selection on click. Upstream only tests X (find on the first thumbnail
+// whose X range contains the click), so in a grid clicking the second row activates
+// the first-row thumbnail of the same column. Add a Y test to pick the right row.
+// (https://github.com/mzur/gnome-shell-wsmatrix/issues/259)
+const _activateThumbnailAtPoint = function (stageX, stageY, time) {
+    const [, x, y] = this.transform_stage_point(stageX, stageY);
+
+    const thumbnail = this._thumbnails.find(
+        t => x >= t.x && x <= t.x + t.width &&
+             y >= t.y && y <= t.y + t.height);
+    if (thumbnail)
+        thumbnail.activate(time);
+};
+
 export default class ThumbnailsBox extends Override {
     enable() {
         const subject = GThumbnailsBox.prototype;
+
+        // Raise the box height cap. GNOME allocates the box at
+        // min(preferredHeight, height * maxThumbnailScale); this cap is meant for a
+        // single row of thumbnails. In a grid it must be multiplied by `rows`,
+        // otherwise the box is clamped to one row and the lower rows fall outside it
+        // (hidden/cropped and not clickable). The getter is only read by GNOME for
+        // this cap; the internal size computation uses the `_maxThumbnailScale`
+        // field, so the thumbnail size is unchanged.
+        this._savedMaxScaleDescriptor =
+            Object.getOwnPropertyDescriptor(subject, 'maxThumbnailScale');
+        Object.defineProperty(subject, 'maxThumbnailScale', {
+            configurable: true,
+            get() {
+                return this._maxThumbnailScale * global.workspace_manager.layout_rows;
+            },
+        });
+
+        // Record the pointer Y to make drop detection grid-aware.
+        this._im.overrideMethod(subject, 'handleDragOver', (original) => {
+            return function (source, actor, x, y, time) {
+                this._wsmatrixDragY = y;
+                return original.call(this, source, actor, x, y, time);
+            };
+        });
+
+        this._im.overrideMethod(subject, '_withinWorkspace', (original) => {
+            return function () {
+                return _withinWorkspace.call(this, ...arguments);
+            };
+        });
+
+        this._im.overrideMethod(subject, '_getPlaceholderTarget', (original) => {
+            return function () {
+                return _getPlaceholderTarget.call(this, ...arguments);
+            };
+        });
+
+        // Grid-aware click (selection of lower-row workspaces).
+        this._im.overrideMethod(subject, '_activateThumbnailAtPoint', (original) => {
+            return function () {
+                return _activateThumbnailAtPoint.call(this, ...arguments);
+            };
+        });
+
         this._im.overrideMethod(subject, 'addThumbnails', (original) => {
             return function () {
                 return addThumbnails.call(this, ...arguments);
@@ -314,5 +463,15 @@ export default class ThumbnailsBox extends Override {
                 return vfunc_allocate.call(this, ...arguments);
             };
         });
+    }
+
+    disable() {
+        // Restore the original maxThumbnailScale getter (not managed by _im).
+        if (this._savedMaxScaleDescriptor) {
+            Object.defineProperty(GThumbnailsBox.prototype, 'maxThumbnailScale',
+                this._savedMaxScaleDescriptor);
+            this._savedMaxScaleDescriptor = null;
+        }
+        super.disable();
     }
 }

--- a/wsmatrix@martin.zurowietz.de/overview/workspacesView.js
+++ b/wsmatrix@martin.zurowietz.de/overview/workspacesView.js
@@ -35,6 +35,58 @@ const _getFirstFitAllWorkspaceBox = function (box, spacing, vertical) {
     return fitAllBox;
 }
 
+// Position of the "current" (centered) cell in SINGLE mode.
+// During a switch we interpolate DIRECTLY between the source and target cells
+// instead of following the index linearly: otherwise a 1 -> 3 switch (adjacent
+// in the grid) travels through the cell of index 2.
+const _currentCell = function (columns) {
+    const adj = this._scrollAdjustment;
+    const from = this._wsmFrom;
+    const to = this._wsmTo;
+
+    const inTransition =
+        adj.get_transition('value') !== null &&
+        !this._gestureActive &&
+        from !== undefined && to !== undefined && from !== to;
+
+    if (inTransition) {
+        const p = Math.max(0, Math.min(1, (adj.value - from) / (to - from)));
+        const fromCol = from % columns, fromRow = Math.floor(from / columns);
+        const toCol = to % columns, toRow = Math.floor(to / columns);
+        return [
+            fromCol + (toCol - fromCol) * p,
+            fromRow + (toRow - fromRow) * p,
+        ];
+    }
+
+    // Static (or gesture): cell of the current scroll value.
+    return [adj.value % columns, Math.floor(adj.value / columns)];
+}
+
+const _getFirstFitSingleWorkspaceBox = function (box, spacing, vertical) {
+    const workspaceManager = global.workspace_manager;
+    const columns = workspaceManager.layout_columns;
+
+    const [width, height] = box.get_size();
+    const [workspace] = this._workspaces;
+
+    const [currentColumn, currentRow] = _currentCell.call(this, columns);
+
+    const [, workspaceWidth] = workspace.get_preferred_width(height);
+
+    // Place workspace 0 so that the current cell is centered. Columns are spaced
+    // by (workspaceWidth + spacing), rows by a viewport height (height + spacing).
+    let [x1, y1] = box.get_origin();
+    x1 += (width - workspaceWidth) / 2;
+    x1 -= currentColumn * (workspaceWidth + spacing);
+    y1 -= currentRow * (height + spacing);
+
+    const fitSingleBox = new Clutter.ActorBox({x1, y1});
+    fitSingleBox.set_size(workspaceWidth, height);
+
+    return fitSingleBox;
+}
+
 const vfunc_allocate = function (box) {
     this.set_allocation(box);
     const workspaceManager = global.workspace_manager;
@@ -71,29 +123,33 @@ const vfunc_allocate = function (box) {
     const [fitAllWidth, fitAllHeight] = fitAllBox.get_size();
 
     workspaces.forEach((child, i) => {
+        const row = Math.floor(i / columns);
+        const column = i % columns;
+
+        // SINGLE: absolute 2D position (each workspace at its grid cell). The
+        // current cell (centered by _getFirstFitSingleWorkspaceBox) follows a direct
+        // source -> target path, so the transition no longer travels through an
+        // intermediate workspace.
+        const singleBox = new Clutter.ActorBox();
+        singleBox.set_size(fitSingleWidth, fitSingleHeight);
+        singleBox.set_origin(
+            fitSingleX1 + (fitSingleWidth + fitSingleSpacing) * column,
+            fitSingleY1 + (fitSingleHeight + fitSingleSpacing) * row);
+
         if (fitMode === FitMode.SINGLE)
-            box = fitSingleBox;
+            box = singleBox;
         else if (fitMode === FitMode.ALL)
             box = fitAllBox;
         else
-            box = fitSingleBox.interpolate(fitAllBox, fitMode);
+            box = singleBox.interpolate(fitAllBox, fitMode);
 
         child.allocate_align_fill(box, 0.5, 0.5, false, false);
 
-        const targetRow = Math.floor((1+i) / columns);
-        const targetColumn = (1+i) % columns;
+        // ALL mode (the overview "all thumbnails" grid): unchanged.
+        const targetRow = Math.floor((1 + i) / columns);
+        const targetColumn = (1 + i) % columns;
 
-        fitSingleBox.set_origin(
-            fitSingleBox.x1 + fitSingleWidth + fitSingleSpacing,
-            fitSingleY1);
-        // TODO Alternative to the previous line that also displays the large
-        // workspaces in the overview in a grid. The animation has to be fixed,
-        // though and the view does not always move to the correct position.
-        // fitSingleBox.set_origin(
-        //     fitSingleX1 + (fitSingleWidth + fitSingleSpacing) * targetColumn,
-        //     fitSingleY1 + (fitSingleHeight + fitSingleSpacing) * targetRow);
-
-        let [, h] = child.get_preferred_height(fitAllWidth)
+        let [, h] = child.get_preferred_height(fitAllWidth);
         fitAllBox.set_origin(
             fitAllX1 + (fitAllWidth + fitAllSpacing) * targetColumn,
             fitAllY1 + (h + fitAllSpacing) * targetRow);
@@ -104,6 +160,24 @@ const vfunc_allocate = function (box) {
 export default class WorkspacesView extends Override {
     enable() {
         const subject = GWorkspacesView.prototype;
+
+        // Capture the switch source/target cell for a direct transition.
+        this._im.overrideMethod(subject, '_activeWorkspaceChanged', (original) => {
+            return function (wm, from, to, direction) {
+                if (!this._gestureActive) {
+                    this._wsmFrom = from;
+                    this._wsmTo = to;
+                }
+                return original.call(this, wm, from, to, direction);
+            };
+        });
+
+        this._im.overrideMethod(subject, '_getFirstFitSingleWorkspaceBox', (original) => {
+            return function () {
+                return _getFirstFitSingleWorkspaceBox.call(this, ...arguments);
+            };
+        });
+
         this._im.overrideMethod(subject, '_getFirstFitAllWorkspaceBox', (original) => {
             return function () {
                 return _getFirstFitAllWorkspaceBox.call(this, ...arguments);

--- a/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceAnimation.js
+++ b/wsmatrix@martin.zurowietz.de/workspacePopup/workspaceAnimation.js
@@ -99,25 +99,31 @@ const MonitorGroup = GObject.registerClass({
         this.activeWorkspace = workspaceIndices[0];
         this.targetWorkspace = workspaceIndices[workspaceIndices.length - 1];
 
-        let x = 0;
-        let y = 0;
+        const fromRow = Math.floor(this.activeWorkspace / this.columns);
+        const fromColumn = this.activeWorkspace % this.columns;
+        const targetRow = Math.floor(this.targetWorkspace / this.columns);
+        const targetColumn = this.targetWorkspace % this.columns;
+        const vertical = targetRow !== fromRow && targetColumn === fromColumn;
 
         for (const i of workspaceIndices) {
-            let fromRow = Math.floor(this.activeWorkspace / this.columns);
-            let fromColumn = this.activeWorkspace % this.columns;
+            // Position each workspace at its real GRID coordinate relative to the
+            // active one, instead of stacking all workspaces linearly by index.
+            // Otherwise a vertical move 1->3 (adjacent in the grid) slides through
+            // workspace 2 (which is in another column).
+            const wsRow = Math.floor(i / this.columns);
+            const wsColumn = i % this.columns;
 
-            let targetRow = Math.floor(this.targetWorkspace / this.columns);
-            let targetColumn = this.targetWorkspace % this.columns;
-            let vertical = targetRow !== fromRow && targetColumn === fromColumn;
+            let x = (wsColumn - fromColumn) * this.baseDistanceX;
+            let y = (wsRow - fromRow) * this.baseDistanceY;
 
-            let ws = workspaceManager.get_workspace_by_index(i);
-            let fullscreen = ws.list_windows().some(w => w.get_monitor() === monitor.index && w.is_fullscreen());
+            const ws = workspaceManager.get_workspace_by_index(i);
+            const fullscreen = ws.list_windows().some(w => w.get_monitor() === monitor.index && w.is_fullscreen());
 
-            if (i > 0 && vertical && !fullscreen && monitor.index === Main.layoutManager.primaryIndex) {
+            if (vertical && wsRow !== fromRow && !fullscreen && monitor.index === Main.layoutManager.primaryIndex) {
                 // We have to shift windows up or down by the height of the panel to prevent having a
                 // visible gap between the windows while switching workspaces. Since fullscreen windows
                 // hide the panel, they don't need to be shifted up or down.
-                y -= Main.panel.height;
+                y -= (wsRow - fromRow) * Main.panel.height;
             }
 
             const group = new WorkspaceGroup(ws, monitor, movingWindow);
@@ -125,16 +131,6 @@ const MonitorGroup = GObject.registerClass({
             this._workspaceGroups.push(group);
             this._container.add_child(group);
             group.set_position(x, y);
-
-            if (targetRow > fromRow)
-                y += this.baseDistanceY;
-            else if (targetRow < fromRow)
-                y -= this.baseDistanceY;
-
-            if (targetColumn > fromColumn)
-                x += this.baseDistanceX;
-            else if (targetColumn < fromColumn)
-                x -= this.baseDistanceX;
         }
 
         this.progress = this.getWorkspaceProgress(activeWorkspace);


### PR DESCRIPTION
## What

This makes the 2D workspace grid fully usable in the Activities overview. Several long-standing issues where only the **top row** of the grid behaved correctly are fixed, plus the workspace switch animation.

### Fixed

1. **Drag-and-drop onto lower rows** (#274) — dropping a window onto a thumbnail in any row but the top landed it on the top-row workspace of that column. GNOME's drop detection (`handleDragOver` / `_withinWorkspace` / `_getPlaceholderTarget`) only tests the X coordinate, and in a grid every column shares the same X range across rows. The pointer Y is now recorded and the helpers filter by row.

2. **Clicking lower rows** (#259) — clicking a thumbnail below the top row selected the top-row workspace of that column. `_activateThumbnailAtPoint` was X-only; it now tests Y too.

3. **Grid cropped / lower rows not clickable** — the thumbnails box was allocated a single row tall: `vfunc_get_preferred_height` returned one row, and GNOME's `height * maxThumbnailScale` cap is sized for one row, so the lower rows were drawn outside the box (cropped, and not receiving clicks). Fixed by returning the full grid height, raising the cap by overriding the `maxThumbnailScale` getter (× `rows`, restored on `disable()`), and dividing `vScale` by `rows` in `vfunc_allocate` so thumbnails keep their size while the whole grid fits. `controlsManagerLayout` no longer multiplies the window-picker offset by `rows` (since `thumbnailsHeight` now spans the whole grid).

4. **Switch animation through intermediate workspaces** — switching between two workspaces that are adjacent in the grid but several indices apart (e.g. `1 → 3` in a 2-column grid) slid through the workspace in between, both for keyboard switches (`Ctrl+Alt+Arrow`) and for clicking a thumbnail in the overview. `workspaceAnimation` now positions each group at its real grid coordinate relative to the active one; `workspacesView` lays out `FitMode.SINGLE` workspaces at their absolute grid cells and interpolates the centered cell directly between the switch source and target instead of following the 1D scroll index. This implements the grid layout the existing `TODO` comment in `workspacesView.js` describes.

## Testing

Developed and tested on **GNOME Shell 46** (X11, 4K display), with both 2×2 and 3×2 grids: drag-drop, clicking, and the switch animation all work on every row and column.

I was **not** able to test on GNOME 47–50. The two largest changes (`thumbnailsBox.js`, `workspacesView.js`) are byte-identical between the `v10` (GNOME 46) line and `master`, so the patched GNOME APIs are unchanged there; the `controlsManagerLayout.js` and `workspaceAnimation.js` hunks were adapted to the current `master` signatures (the `spacing` parameter and `global.compositor.disable_unredirect()`). A quick check on a newer Shell would be very welcome.

## Notes

- The `maxThumbnailScale` getter override is restored in `disable()`.
- Commits are split by concern: one for the overview grid interaction (drag / click / layout), one for the switch animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
